### PR TITLE
fea: add rwa contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ out/
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 /broadcast/*/97/
+/broadcast/*/11155111/
 
 # Dotenv file
 .env

--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,9 @@ extra_output = ["storageLayout"]
 [rpc_endpoints]
 bsc_testnet = "https://bsc-testnet-dataseed.bnbchain.org"
 bsc = "https://bsc-dataseed.binance.org"
+sepolia = "https://sepolia.infura.io/v3/${INFURA_API_KEY}"
 
 [etherscan]
 bsc = { key = "${BSCSCAN_API_KEY}" }
 bsc_testnet = { key = "${BSCSCAN_API_KEY}" }
+sepolia = { key = "${ETHERSCAN_API_KEY}" }

--- a/script/rwa/RWAEarnPool.s.sol
+++ b/script/rwa/RWAEarnPool.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../../src/rwa/RWAEarnPool.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract RWAEarnPoolDeploy is Script {
+  address USD1 = 0x0e82c3284a5a957279dF552269f1808C712caC34;
+  address USDC = 0x3aaaa86458d576BafCB1B7eD290434F0696dA65c;
+  address vault = 0xC2b55783609f5219cfC13FF31f960b6C7027241b;
+  address shareToken = 0xABC226faDdC07d81C975Efa7C6b3F45f57782551;
+
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    RWAEarnPool impl = new RWAEarnPool();
+
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(impl.initialize.selector, deployer, deployer, deployer, vault, shareToken)
+    );
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/rwa/deploy_mockVault.s.sol
+++ b/script/rwa/deploy_mockVault.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+
+import "../../src/mock/MockAsyncVault.sol";
+
+contract DeployMockVault is Script {
+  address public USDC = 0x37dd428A109966c42eFcad2e4D233Bd72dc43103;
+  address public shareToken = 0xC8C0A2098BE100F7CBBA414c55966F754d851b84;
+
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+    MockAsyncVault mockVault = new MockAsyncVault(USDC, shareToken, 1e18);
+    vm.stopPrank();
+
+    console.log("MockAsyncVault: ", address(mockVault));
+  }
+}

--- a/script/rwa/deploy_rwa.s.sol
+++ b/script/rwa/deploy_rwa.s.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import "../../src/rwa/RWAEarnPool.sol";
+import "../../src/rwa/RWAAdapter.sol";
+import "../../src/rwa/OTCManager.sol";
+
+contract DeployRWA is Script {
+  address public USD1 = 0x3189e817d80048321f1809523F1eB75D1cF16020;
+  address public USDC = 0x37dd428A109966c42eFcad2e4D233Bd72dc43103;
+  address public vault = 0xd6227C734d9f3081520D964cB8B09f0B3386DD80;
+  address public shareToken = 0xC8C0A2098BE100F7CBBA414c55966F754d851b84;
+
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    address admin = deployer;
+    address manager = deployer;
+    address pauser = deployer;
+    address bot = deployer;
+    address otcWallet = deployer;
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    RWAEarnPool earnPoolImpl = new RWAEarnPool();
+    RWAAdapter adapterImpl = new RWAAdapter(USD1, USDC);
+    OTCManager otcManagerImpl = new OTCManager(USD1, USDC);
+
+    RWAEarnPool earnPool = RWAEarnPool(address(new ERC1967Proxy(address(earnPoolImpl), "")));
+
+    RWAAdapter adapter = RWAAdapter(address(new ERC1967Proxy(address(adapterImpl), "")));
+
+    OTCManager otcManager = OTCManager(address(new ERC1967Proxy(address(otcManagerImpl), "")));
+
+    earnPool.initialize(admin, manager, pauser, address(USD1), "USD1.Treasury", "USD1.Treasury", address(adapter));
+
+    adapter.initialize(
+      admin,
+      manager,
+      bot,
+      address(earnPool),
+      address(otcManager),
+      address(vault),
+      address(shareToken)
+    );
+
+    otcManager.initialize(admin, manager, bot, address(adapter), otcWallet);
+    vm.stopPrank();
+
+    console.log("RWAEarnPool: ", address(earnPool));
+    console.log("RWAAdapter: ", address(adapter));
+    console.log("OTCManager: ", address(otcManager));
+  }
+}

--- a/script/rwa/deploy_rwa.s.sol
+++ b/script/rwa/deploy_rwa.s.sol
@@ -40,15 +40,7 @@ contract DeployRWA is Script {
 
     earnPool.initialize(admin, manager, pauser, address(USD1), "USD1.Treasury", "USD1.Treasury", address(adapter));
 
-    adapter.initialize(
-      admin,
-      manager,
-      bot,
-      address(earnPool),
-      address(otcManager),
-      address(vault),
-      address(shareToken)
-    );
+    adapter.initialize(admin, manager, bot, address(earnPool), address(vault), address(shareToken));
 
     otcManager.initialize(admin, manager, bot, address(adapter), otcWallet);
     vm.stopPrank();

--- a/script/rwa/deploy_rwa.s.sol
+++ b/script/rwa/deploy_rwa.s.sol
@@ -7,13 +7,15 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import "../../src/rwa/RWAEarnPool.sol";
 import "../../src/rwa/RWAAdapter.sol";
-import "../../src/rwa/OTCManager.sol";
 
 contract DeployRWA is Script {
-  address public USD1 = 0x3189e817d80048321f1809523F1eB75D1cF16020;
-  address public USDC = 0x37dd428A109966c42eFcad2e4D233Bd72dc43103;
-  address public vault = 0xd6227C734d9f3081520D964cB8B09f0B3386DD80;
-  address public shareToken = 0xC8C0A2098BE100F7CBBA414c55966F754d851b84;
+  address public USDT = 0x55d398326f99059fF775485246999027B3197955;
+  address public JTRSYUSDTVault = 0x6e6B8498415083a4386BE83DD59Edd4366402FFa;
+  address public JAAAUSDTVault = 0xcbAfe61d84C6Fb88252a6Adf1C9CB0B9D029cb99;
+  address public JTRSYUSDTVShareToken = 0xa5d465251fBCc907f5Dd6bB2145488DFC6a2627b;
+  address public JAAAUSDTVShareToken = 0x58F93d6b1EF2F44eC379Cb975657C132CBeD3B6b;
+  address pauser = 0xEEfebb1546d88EA0909435DF6f615084DD3c5Bd8;
+  address bot = 0x91fC4BA20685339781888eCA3E9E1c12d40F0e13;
 
   function run() public {
     uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
@@ -22,31 +24,47 @@ contract DeployRWA is Script {
 
     address admin = deployer;
     address manager = deployer;
-    address pauser = deployer;
-    address bot = deployer;
-    address otcWallet = deployer;
-
     vm.startBroadcast(deployerPrivateKey);
+    deployRWA(
+      admin,
+      manager,
+      pauser,
+      bot,
+      USDT,
+      "USDT.Treasury",
+      "USDT.Treasury",
+      JTRSYUSDTVault,
+      JTRSYUSDTVShareToken
+    );
+    deployRWA(admin, manager, pauser, bot, USDT, "USDT.AAA", "USDT.AAA", JAAAUSDTVault, JAAAUSDTVShareToken);
+    vm.stopPrank();
+  }
 
+  function deployRWA(
+    address admin,
+    address manager,
+    address pauser,
+    address bot,
+    address asset,
+    string memory name,
+    string memory symbol,
+    address vault,
+    address shareToken
+  ) private {
     RWAEarnPool earnPoolImpl = new RWAEarnPool();
-    RWAAdapter adapterImpl = new RWAAdapter(USD1, USDC);
-    OTCManager otcManagerImpl = new OTCManager(USD1, USDC);
+    RWAAdapter adapterImpl = new RWAAdapter(asset, asset);
 
     RWAEarnPool earnPool = RWAEarnPool(address(new ERC1967Proxy(address(earnPoolImpl), "")));
 
     RWAAdapter adapter = RWAAdapter(address(new ERC1967Proxy(address(adapterImpl), "")));
 
-    OTCManager otcManager = OTCManager(address(new ERC1967Proxy(address(otcManagerImpl), "")));
+    earnPool.initialize(admin, manager, pauser, asset, name, symbol, address(adapter));
 
-    earnPool.initialize(admin, manager, pauser, address(USD1), "USD1.Treasury", "USD1.Treasury", address(adapter));
+    adapter.initialize(admin, manager, bot, address(earnPool), vault, shareToken);
 
-    adapter.initialize(admin, manager, bot, address(earnPool), address(vault), address(shareToken));
-
-    otcManager.initialize(admin, manager, bot, address(adapter), otcWallet);
-    vm.stopPrank();
-
+    console.log("--------------------------", name, "--------------------------");
     console.log("RWAEarnPool: ", address(earnPool));
     console.log("RWAAdapter: ", address(adapter));
-    console.log("OTCManager: ", address(otcManager));
+    console.log("-----------------------------------------------------");
   }
 }

--- a/script/rwa/deploy_rwa_config.s.sol
+++ b/script/rwa/deploy_rwa_config.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import "../../src/rwa/RWAEarnPool.sol";
+import "../../src/rwa/RWAAdapter.sol";
+
+contract DeployRWAConfig is Script {
+  address earnPool1 = 0x4C78D6aFfb5063Af9af922874B0885Bc3f77d114;
+  address adapter1 = 0xc12544BE695b6f5aa0A609ab5a2d80B5AD5170b6;
+
+  address earnPool2 = 0x5Ecf6fD97cEB71c3A6C66BcfCaAF66Aeb28edf43;
+  address adapter2 = 0x587b55F3c6Ef0693c93404d1c9B8fE81b2cB7205;
+
+  address withdrawFeeRecipient = 0x2E2Eed557FAb1d2E11fEA1E1a23FF8f1b23551f3;
+  address profitFeeRecipient = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+
+  uint256 withdrawFeeRate = 0.001 ether; // 0.1%
+  uint256 profitFeeRate = 0.05 ether; // 5%
+
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+    RWAEarnPool(earnPool1).setFeeReceiver(withdrawFeeRecipient);
+    RWAEarnPool(earnPool1).setWithdrawFeeRate(withdrawFeeRate);
+    RWAAdapter(adapter1).setFeeReceiver(profitFeeRecipient);
+    RWAAdapter(adapter1).setFeeRate(profitFeeRate);
+
+    RWAEarnPool(earnPool2).setFeeReceiver(withdrawFeeRecipient);
+    RWAEarnPool(earnPool2).setWithdrawFeeRate(withdrawFeeRate);
+    RWAAdapter(adapter2).setFeeReceiver(profitFeeRecipient);
+    RWAAdapter(adapter2).setFeeRate(profitFeeRate);
+    vm.stopPrank();
+  }
+}

--- a/script/rwa/deploy_rwa_transferRole.s.sol
+++ b/script/rwa/deploy_rwa_transferRole.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "@openzeppelin/contracts/access/IAccessControl.sol";
+
+contract DeployRWAConfig is Script {
+  address earnPool1 = 0x4C78D6aFfb5063Af9af922874B0885Bc3f77d114;
+  address adapter1 = 0xc12544BE695b6f5aa0A609ab5a2d80B5AD5170b6;
+
+  address earnPool2 = 0x5Ecf6fD97cEB71c3A6C66BcfCaAF66Aeb28edf43;
+  address adapter2 = 0x587b55F3c6Ef0693c93404d1c9B8fE81b2cB7205;
+
+  address admin = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
+  address manager = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+
+  bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+    transferRole(earnPool1, deployer, admin, manager);
+    transferRole(adapter1, deployer, admin, manager);
+    transferRole(earnPool2, deployer, admin, manager);
+    transferRole(adapter2, deployer, admin, manager);
+    vm.stopPrank();
+  }
+
+  function transferRole(address ca, address deployer, address admin, address manager) private {
+    IAccessControl(ca).grantRole(DEFAULT_ADMIN_ROLE, admin);
+    IAccessControl(ca).grantRole(MANAGER, manager);
+    IAccessControl(ca).revokeRole(MANAGER, deployer);
+    IAccessControl(ca).revokeRole(DEFAULT_ADMIN_ROLE, deployer);
+  }
+}

--- a/script/token/MockERC20.s.sol
+++ b/script/token/MockERC20.s.sol
@@ -22,7 +22,7 @@ contract MockERC20Script is Script {
 
     vm.startBroadcast(deployerPrivateKey);
 
-    MockERC20 mockToken = new MockERC20("SOLV", "solv");
+    MockERC20 mockToken = new MockERC20("USDC", "USDC");
 
     console.log("mockToken address: %s", address(mockToken));
   }

--- a/src/mock/MockAsyncVault.sol
+++ b/src/mock/MockAsyncVault.sol
@@ -16,6 +16,8 @@ contract MockAsyncVault is IAsyncVault {
   address public asset;
   MockERC20 public shareToken;
 
+  uint256 public claimableAssets;
+
   uint256 public constant PRECISION = 1e18;
 
   constructor(address _asset, address _shareToken, uint256 _convertRate) {
@@ -75,5 +77,35 @@ contract MockAsyncVault is IAsyncVault {
 
   function setConvertRate(uint256 _convertRate) external {
     convertRate = _convertRate;
+  }
+
+  function setClaimableAssets(uint256 _claimableAssets) external {
+    claimableAssets = _claimableAssets;
+  }
+
+  function claimCancelDepositRequest(
+    uint256 requestId,
+    address receiver,
+    address controller
+  ) external returns (uint256 assets) {
+    IERC20(asset).transfer(receiver, claimableAssets);
+    return claimableAssets;
+  }
+
+  function claimCancelRedeemRequest(
+    uint256 requestId,
+    address receiver,
+    address controller
+  ) external returns (uint256 shares) {
+    shareToken.transfer(receiver, claimableAssets);
+    return claimableAssets;
+  }
+
+  function claimableCancelDepositRequest(uint256 requestId, address controller) external view returns (uint256) {
+    return claimableAssets;
+  }
+
+  function claimableCancelRedeemRequest(uint256 requestId, address controller) external view returns (uint256) {
+    return claimableAssets;
   }
 }

--- a/src/mock/MockAsyncVault.sol
+++ b/src/mock/MockAsyncVault.sol
@@ -16,8 +16,6 @@ contract MockAsyncVault is IAsyncVault {
   address public asset;
   MockERC20 public shareToken;
 
-  uint256 public claimableAssets;
-
   uint256 public constant PRECISION = 1e18;
 
   constructor(address _asset, address _shareToken, uint256 _convertRate) {
@@ -77,35 +75,5 @@ contract MockAsyncVault is IAsyncVault {
 
   function setConvertRate(uint256 _convertRate) external {
     convertRate = _convertRate;
-  }
-
-  function setClaimableAssets(uint256 _claimableAssets) external {
-    claimableAssets = _claimableAssets;
-  }
-
-  function claimCancelDepositRequest(
-    uint256 requestId,
-    address receiver,
-    address controller
-  ) external returns (uint256 assets) {
-    IERC20(asset).transfer(receiver, claimableAssets);
-    return claimableAssets;
-  }
-
-  function claimCancelRedeemRequest(
-    uint256 requestId,
-    address receiver,
-    address controller
-  ) external returns (uint256 shares) {
-    shareToken.transfer(receiver, claimableAssets);
-    return claimableAssets;
-  }
-
-  function claimableCancelDepositRequest(uint256 requestId, address controller) external view returns (uint256) {
-    return claimableAssets;
-  }
-
-  function claimableCancelRedeemRequest(uint256 requestId, address controller) external view returns (uint256) {
-    return claimableAssets;
   }
 }

--- a/src/mock/MockAsyncVault.sol
+++ b/src/mock/MockAsyncVault.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../rwa/interface/IAsyncVault.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+import "./MockERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MockAsyncVault is IAsyncVault {
+  using Math for uint256;
+  uint256 public convertRate;
+
+  mapping(address => uint256) public pendingDeposits;
+  mapping(address => uint256) public pendingRedeems;
+
+  address public asset;
+  MockERC20 public shareToken;
+
+  uint256 public constant PRECISION = 1e18;
+
+  constructor(address _asset, address _shareToken, uint256 _convertRate) {
+    require(_asset != address(0), "MockAsyncVault: asset is the zero address");
+    require(_shareToken != address(0), "MockAsyncVault: shareToken is the zero address");
+    require(_convertRate > 0, "MockAsyncVault: convertRate is zero");
+    asset = _asset;
+    shareToken = MockERC20(_shareToken);
+    convertRate = _convertRate;
+  }
+
+  function totalAssets() public view returns (uint256) {
+    return convertToAssets(shareToken.totalSupply());
+  }
+  function convertToShares(uint256 assets) public view returns (uint256) {
+    return assets.mulDiv(PRECISION, convertRate);
+  }
+  function convertToAssets(uint256 shares) public view returns (uint256) {
+    return shares.mulDiv(convertRate, PRECISION);
+  }
+  function balanceOf(address account) external view returns (uint256) {
+    return shareToken.balanceOf(account);
+  }
+  function requestDeposit(uint256 assets, address controller, address owner) external returns (uint256) {
+    IERC20(asset).transferFrom(msg.sender, address(this), assets);
+    uint256 share = convertToShares(assets);
+    pendingDeposits[owner] += share;
+    return share;
+  }
+  function requestRedeem(uint256 shares, address controller, address owner) external returns (uint256) {
+    require(shares <= shareToken.balanceOf(owner), "MockAsyncVault: insufficient shares");
+    shareToken.burn(owner, shares);
+    pendingRedeems[owner] += shares;
+    return shares;
+  }
+  function maxMint(address account) external view returns (uint256) {
+    return pendingDeposits[account];
+  }
+  function maxRedeem(address account) external view returns (uint256) {
+    return pendingRedeems[account];
+  }
+  function mint(uint256 shares, address receiver) external returns (uint256) {
+    require(shares <= pendingDeposits[receiver], "MockAsyncVault: insufficient pending deposits");
+    pendingDeposits[receiver] -= shares;
+
+    shareToken.mint(receiver, shares);
+    return convertToAssets(shares);
+  }
+  function redeem(uint256 shares, address receiver, address owner) external returns (uint256) {
+    require(shares <= pendingRedeems[owner], "MockAsyncVault: insufficient pending redeems");
+    pendingRedeems[owner] -= shares;
+
+    uint256 assets = convertToAssets(shares);
+    IERC20(asset).transfer(receiver, assets);
+    return assets;
+  }
+
+  function setConvertRate(uint256 _convertRate) external {
+    convertRate = _convertRate;
+  }
+}

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -10,4 +10,8 @@ contract MockERC20 is ERC20, ERC20Permit {
   function mint(address to, uint256 amount) external {
     _mint(to, amount);
   }
+
+  function burn(address from, uint256 amount) external {
+    _burn(from, amount);
+  }
 }

--- a/src/rwa/OTCManager.sol
+++ b/src/rwa/OTCManager.sol
@@ -95,9 +95,10 @@ contract OTCManager is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
    * @dev allows manager to withdraw reward tokens for emergency or recover any other mistaken ERC20 tokens.
    * @param token ERC20 token address
    * @param amount token amount
+   * @param receiver address to receive the tokens
    */
-  function emergencyWithdraw(address token, uint256 amount) external onlyRole(MANAGER) {
-    IERC20(token).safeTransfer(msg.sender, amount);
+  function emergencyWithdraw(address token, uint256 amount, address receiver) external onlyRole(MANAGER) {
+    IERC20(token).safeTransfer(receiver, amount);
     emit EmergencyWithdraw(token, amount);
   }
 

--- a/src/rwa/OTCManager.sol
+++ b/src/rwa/OTCManager.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract OTCManager is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
+  using SafeERC20 for IERC20;
+
+  /* VARIABLES */
+  address public adapter;
+  address public otcWallet;
+
+  /* IMMUTABLES */
+  address public immutable USD1;
+  address public immutable USDC;
+
+  /* CONSTANTS */
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+  bytes32 public constant BOT = keccak256("BOT");
+
+  /* EVENTS */
+  event EmergencyWithdraw(address token, uint256 amount);
+
+  /* CONSTRUCTOR */
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  /// @param _USD1 The address of the USD1 token.
+  /// @param _USDC The address of the USDC token.
+  constructor(address _USD1, address _USDC) {
+    require(_USD1 != address(0), "USD1 is zero address");
+    require(_USDC != address(0), "USDC is zero address");
+    _disableInitializers();
+    USD1 = _USD1;
+    USDC = _USDC;
+  }
+
+  /* INITIALIZER */
+  /**
+   * @dev initializes the contract.
+   * @param _admin The address of the admin.
+   * @param _manager The address of the manager.
+   * @param _bot The address of the bot.
+   * @param _adapter The address of the adapter.
+   * @param _otcWallet The address of the OTC wallet.
+   */
+  function initialize(
+    address _admin,
+    address _manager,
+    address _bot,
+    address _adapter,
+    address _otcWallet
+  ) external initializer {
+    require(_admin != address(0), "Admin is zero address");
+    require(_manager != address(0), "Manager is zero address");
+    require(_adapter != address(0), "Adapter is zero address");
+    require(_otcWallet != address(0), "OTC wallet is zero address");
+
+    __AccessControlEnumerable_init();
+
+    _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    _grantRole(MANAGER, _manager);
+    _grantRole(BOT, _bot);
+
+    adapter = _adapter;
+    otcWallet = _otcWallet;
+  }
+
+  /* EXTERNAL FUNCTIONS */
+  /**
+   * @dev swaps tokens from adapter to OTC wallet.
+   * @param token The address of the token to swap (USD1 or USDC).
+   * @param amount The amount of tokens to swap.
+   */
+  function swapToken(address token, uint256 amount) external {
+    require(msg.sender == adapter, "Only adapter can call this function");
+    require(token == USD1 || token == USDC, "Invalid token");
+    IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+    IERC20(token).safeTransfer(otcWallet, amount);
+  }
+
+  /**
+   * @dev transfers tokens from OTC wallet to adapter.
+   * @param token The address of the token to transfer (USD1 or USDC).
+   * @param amount The amount of tokens to transfer.
+   */
+  function transferToAdapter(address token, uint256 amount) external onlyRole(BOT) {
+    require(amount > 0, "Amount must be greater than zero");
+    require(token == USD1 || token == USDC, "Invalid token");
+    IERC20(token).safeTransfer(adapter, amount);
+  }
+
+  /**
+   * @dev allows manager to withdraw reward tokens for emergency or recover any other mistaken ERC20 tokens.
+   * @param token ERC20 token address
+   * @param amount token amount
+   */
+  function emergencyWithdraw(address token, uint256 amount) external onlyRole(MANAGER) {
+    IERC20(token).safeTransfer(msg.sender, amount);
+    emit EmergencyWithdraw(token, amount);
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/src/rwa/RWAAdapter.sol
+++ b/src/rwa/RWAAdapter.sol
@@ -315,8 +315,12 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   function _requestDepositToVault(uint256 amountUSDC) private {
     // approve amount to vault
     IERC20(USDC).safeIncreaseAllowance(vault, amountUSDC);
+
     // request deposit to vault
+    // check USDC balance decreased
+    uint256 before = IERC20(USDC).balanceOf(address(this));
     IAsyncVault(vault).requestDeposit(amountUSDC, address(this), address(this));
+    require(before - IERC20(USDC).balanceOf(address(this)) == amountUSDC, "USDC request deposit failed");
 
     emit RequestDepositToVault(amountUSDC);
   }

--- a/src/rwa/RWAAdapter.sol
+++ b/src/rwa/RWAAdapter.sol
@@ -42,6 +42,7 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   bytes32 public constant BOT = keccak256("BOT");
 
   uint256 public constant PRECISION = 1e18;
+  uint256 public constant MAX_FEE_RATE = 3 * 1e17; // 30%
 
   /* IMMUTABLE */
   address public immutable USD1;
@@ -53,6 +54,10 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   event MintVaultShares(uint256 shares);
   event WithdrawFromVault(uint256 shares, uint256 totalAmount, uint256 feeAmount);
   event EmergencyWithdraw(address token, uint256 amount);
+  event SetFeeReceiver(address feeReceiver);
+  event SetFeeRate(uint256 feeRate);
+  event SetToUSDCLossRate(uint256 toUSDCLossRate);
+  event SetToUSD1LossRate(uint256 toUSD1LossRate);
 
   /* CONSTRUCTOR */
   /// @custom:oz-upgrades-unsafe-allow constructor
@@ -147,6 +152,7 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
    */
   function depositRewards(uint256 amountUSDC) external onlyRole(MANAGER) {
     require(amountUSDC > 0, "Amount must be greater than zero");
+    require(IRWAEarnPool(earnPool).totalSupply() > 0, "Earn pool has no shares");
 
     // transfer USDC from manager to this contract
     IERC20(USDC).safeTransferFrom(msg.sender, address(this), amountUSDC);
@@ -249,6 +255,7 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   function setFeeReceiver(address _feeReceiver) external onlyRole(MANAGER) {
     require(_feeReceiver != address(0), "feeReceiver is zero");
     feeReceiver = _feeReceiver;
+    emit SetFeeReceiver(_feeReceiver);
   }
 
   /**
@@ -256,8 +263,9 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
    * @param _feeRate The fee rate (18 decimals)
    */
   function setFeeRate(uint256 _feeRate) external onlyRole(MANAGER) {
-    require(_feeRate <= PRECISION, "feeRate too high"); // max 10%
+    require(_feeRate <= MAX_FEE_RATE, "feeRate too high"); // max 30%
     feeRate = _feeRate;
+    emit SetFeeRate(_feeRate);
   }
 
   /**
@@ -267,6 +275,7 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   function setToUSDCLossRate(uint256 _toUSDCLossRate) external onlyRole(MANAGER) {
     require(_toUSDCLossRate <= PRECISION, "toUSDCLossRate too high");
     toUSDCLossRate = _toUSDCLossRate;
+    emit SetToUSDCLossRate(_toUSDCLossRate);
   }
 
   /**
@@ -276,6 +285,7 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   function setToUSD1LossRate(uint256 _toUSD1LossRate) external onlyRole(MANAGER) {
     require(_toUSD1LossRate <= PRECISION, "toUSD1LossRate too high");
     toUSD1LossRate = _toUSD1LossRate;
+    emit SetToUSD1LossRate(_toUSD1LossRate);
   }
 
   /**
@@ -306,14 +316,32 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   }
 
   /**
-   * @dev allows manager to withdraw reward tokens for emergency or recover any other mistaken ERC20 tokens.
+   * @dev allows manager to withdraw tokens for emergency
    * @param token ERC20 token address
    * @param amount token amount
    * @param receiver receiver address
    */
   function emergencyWithdraw(address token, uint256 amount, address receiver) external onlyRole(MANAGER) {
+    require(amount > 0, "Amount must be greater than zero");
+    require(receiver != address(0), "Receiver is zero address");
     IERC20(token).safeTransfer(receiver, amount);
     emit EmergencyWithdraw(token, amount);
+  }
+
+  /**
+   * @dev claim cancel deposit request from vault
+   */
+  function claimCancelDepositRequest() external onlyRole(BOT) {
+    require(IAsyncVault(vault).claimableCancelDepositRequest(0, address(this)) > 0, "No claimable deposit");
+    IAsyncVault(vault).claimCancelDepositRequest(0, address(this), address(this));
+  }
+
+  /**
+   * @dev claim cancel redeem request from vault
+   */
+  function claimCancelRedeemRequest() external onlyRole(BOT) {
+    require(IAsyncVault(vault).claimableCancelRedeemRequest(0, address(this)) > 0, "No claimable redeem");
+    IAsyncVault(vault).claimCancelRedeemRequest(0, address(this), address(this));
   }
 
   /* INTERNAL FUNCTIONS */
@@ -332,6 +360,10 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
 
   function _updateVaultAssets() private {
     uint256 newVaultTotalAssets = getVaultTotalAssets();
+    if (newVaultTotalAssets <= lastVaultTotalAssets) {
+      // no profit
+      return;
+    }
     uint256 totalInterest = newVaultTotalAssets - lastVaultTotalAssets;
 
     // charge fee, asset is USDC

--- a/src/rwa/RWAAdapter.sol
+++ b/src/rwa/RWAAdapter.sol
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { IAsyncVault } from "./interface/IAsyncVault.sol";
+import { IRWAEarnPool } from "./interface/IRWAEarnPool.sol";
+import { IOTCManager } from "./interface/IOTCManager.sol";
+
+contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
+  using SafeERC20 for IERC20;
+  using Math for uint256;
+
+  /* VARIABLES */
+  // otc manager address
+  address public otcManager;
+  // earn pool address
+  address public earnPool;
+  // vault address
+  address public vault;
+  // vault share token address
+  address public shareToken;
+  // fee receiver address
+  address public feeReceiver;
+  // loss rate when swap USD1 to USDC, 18 decimals
+  uint256 public toUSDCLossRate;
+  // loss rate when swap USDC to USD1, 18 decimals
+  uint256 public toUSD1LossRate;
+  // fee rate, 18 decimals
+  uint256 public feeRate;
+  // accumulated fee, asset is USDC
+  uint256 public fee;
+  // last total assets in vault
+  uint256 public lastVaultTotalAssets;
+
+  /* CONSTANTS */
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+  bytes32 public constant BOT = keccak256("BOT");
+
+  uint256 public constant PRECISION = 1e18;
+
+  /* IMMUTABLE */
+  address public immutable USD1;
+  address public immutable USDC;
+
+  /* EVENTS */
+  event RequestDepositToVault(uint256 amount);
+  event RequestWithdrawFromVault(uint256 shares, uint256 expectAmount);
+  event MintVaultShares(uint256 shares);
+  event WithdrawFromVault(uint256 shares, uint256 totalAmount, uint256 feeAmount);
+  event EmergencyWithdraw(address token, uint256 amount);
+
+  /* CONSTRUCTOR */
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  /// @param _USD1 The address of the USD1 token.
+  /// @param _USDC The address of the USDC token.
+  constructor(address _USD1, address _USDC) {
+    require(_USD1 != address(0), "USD1 is zero address");
+    require(_USDC != address(0), "USDC is zero address");
+    _disableInitializers();
+    USD1 = _USD1;
+    USDC = _USDC;
+  }
+
+  /* INITIALIZER */
+  /**
+   * @dev initializes the contract.
+   * @param _admin The address of the admin.
+   * @param _manager The address of the manager.
+   * @param _bot The address of the bot.
+   * @param _earnPool The address of the earn pool.
+   * @param _otcManager The address of the OTC manager.
+   * @param _vault The address of the vault.
+   * @param _shareToken The address of the vault share token.
+   */
+  function initialize(
+    address _admin,
+    address _manager,
+    address _bot,
+    address _earnPool,
+    address _otcManager,
+    address _vault,
+    address _shareToken
+  ) public initializer {
+    require(_admin != address(0), "Admin address cannot be zero");
+    require(_manager != address(0), "Manager address cannot be zero");
+    require(_bot != address(0), "Bot address cannot be zero");
+    require(_earnPool != address(0), "EarnPool address cannot be zero");
+    require(_otcManager != address(0), "OTCManager address cannot be zero");
+    require(_vault != address(0), "Vault address cannot be zero");
+    require(_shareToken != address(0), "ShareToken address cannot be zero");
+
+    // initialize inherited contracts
+    __AccessControlEnumerable_init();
+
+    // setup roles
+    _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    _grantRole(MANAGER, _manager);
+    _grantRole(BOT, _bot);
+
+    // setup variables
+    earnPool = _earnPool;
+    otcManager = _otcManager;
+    vault = _vault;
+    shareToken = _shareToken;
+  }
+
+  /* EXTERNAL FUNCTIONS */
+  /**
+   * @dev request to deposit USDC to vault
+   * @param amountUSDC The amount of USDC to deposit
+   */
+  function requestDepositToVault(uint256 amountUSDC) external onlyRole(BOT) {
+    require(amountUSDC > 0, "Amount must be greater than zero");
+    _requestDepositToVault(amountUSDC);
+  }
+
+  /**
+   * @dev finish deposit request and mint vault shares
+   */
+  function depositToVault() external onlyRole(BOT) {
+    // get max mint amount from vault
+    uint256 maxMint = IAsyncVault(vault).maxMint(address(this));
+    // require max mint amount > 0
+    require(maxMint > 0, "maxMint is zero");
+    // update vault assets and charge fee
+    _updateVaultAssets();
+
+    // mint vault shares
+    IAsyncVault(vault).mint(maxMint, address(this));
+
+    // update lastVaultTotalAssets
+    lastVaultTotalAssets = getVaultTotalAssets();
+
+    emit MintVaultShares(maxMint);
+  }
+
+  /**
+   * @dev deposit rewards to earn pool
+   * @param amountUSDC The amount of USDC to deposit as rewards
+   */
+  function depositRewards(uint256 amountUSDC) external onlyRole(MANAGER) {
+    require(amountUSDC > 0, "Amount must be greater than zero");
+
+    // transfer USDC from manager to this contract
+    IERC20(USDC).safeTransferFrom(msg.sender, address(this), amountUSDC);
+    // request deposit to vault
+    _requestDepositToVault(amountUSDC);
+
+    // convert USDC to USD1
+    uint256 amountUSD1 = USDCToUSD1(amountUSDC);
+    // notify interest to earn pool
+    IRWAEarnPool(earnPool).notifyInterest(amountUSD1);
+  }
+
+  /**
+   * @dev request to withdraw USDC from vault
+   * @param amountUSDC The amount of USDC to withdraw
+   */
+  function requestWithdrawFromVault(uint256 amountUSDC) external onlyRole(BOT) {
+    require(amountUSDC > 0, "Amount must be greater than zero");
+    // update vault assets and charge fee
+    _updateVaultAssets();
+
+    // calculate shares to redeem
+    uint256 redeemShares = IAsyncVault(vault).convertToShares(amountUSDC);
+    // approve shares to vault
+    IERC20(shareToken).approve(vault, redeemShares);
+    // request redeem from vault
+    IAsyncVault(vault).requestRedeem(redeemShares, address(this), address(this));
+
+    // update lastVaultTotalAssets
+    lastVaultTotalAssets = getVaultTotalAssets();
+
+    emit RequestWithdrawFromVault(redeemShares, amountUSDC);
+  }
+
+  /**
+   * @dev finish withdraw request and redeem USDC from vault
+   * @param claimFee Whether to claim the accumulated fee
+   */
+  function withdrawFromVault(bool claimFee) external onlyRole(BOT) {
+    // get max redeem amount from vault
+    uint256 maxRedeem = IAsyncVault(vault).maxRedeem(address(this));
+    // require max redeem amount > 0
+    require(maxRedeem > 0, "maxRedeem is zero");
+
+    // redeem from vault
+    uint256 before = IERC20(USDC).balanceOf(address(this));
+    IAsyncVault(vault).redeem(maxRedeem, address(this), address(this));
+    uint256 totalAmount = IERC20(USDC).balanceOf(address(this)) - before;
+
+    uint256 feeAmount;
+    if (claimFee && fee > 0) {
+      require(feeReceiver != address(0), "feeReceiver is zero");
+      require(totalAmount >= fee, "totalAmount < fee");
+
+      // transfer fee to feeReceiver
+      IERC20(USDC).safeTransfer(feeReceiver, fee);
+      feeAmount = fee;
+      fee = 0;
+    }
+
+    emit WithdrawFromVault(maxRedeem, totalAmount, feeAmount);
+  }
+
+  /**
+   * @dev finish withdraw requests in earn pool
+   * @param amountUSD1 The amount of USD1 to cover withdraw
+   */
+  function finishEarnPoolWithdraw(uint256 amountUSD1) external onlyRole(BOT) {
+    require(amountUSD1 > 0, "Amount must be greater than zero");
+    IERC20(USD1).safeIncreaseAllowance(earnPool, amountUSD1);
+    IRWAEarnPool(earnPool).finishWithdraw(amountUSD1);
+  }
+
+  /**
+   * @dev swap token to otc manager
+   * @param token The address of the token to swap
+   * @param amount The amount of the token to swap
+   */
+  function swapToken(address token, uint256 amount) external onlyRole(BOT) {
+    require(token == USD1 || token == USDC, "Invalid token");
+    require(amount > 0, "Amount must be greater than zero");
+    IERC20(token).safeIncreaseAllowance(otcManager, amount);
+    IOTCManager(otcManager).swapToken(token, amount);
+  }
+
+  /**
+   * @dev update vault assets and charge fee
+   */
+  function updateVaultAssets() external onlyRole(BOT) {
+    _updateVaultAssets();
+  }
+
+  /* MANAGER FUNCTIONS */
+  /**
+   * @dev set fee receiver address
+   * @param _feeReceiver The address of the fee receiver
+   */
+  function setFeeReceiver(address _feeReceiver) external onlyRole(MANAGER) {
+    require(_feeReceiver != address(0), "feeReceiver is zero");
+    feeReceiver = _feeReceiver;
+  }
+
+  /**
+   * @dev set fee rate
+   * @param _feeRate The fee rate (18 decimals)
+   */
+  function setFeeRate(uint256 _feeRate) external onlyRole(MANAGER) {
+    require(_feeRate <= PRECISION, "feeRate too high"); // max 10%
+    feeRate = _feeRate;
+  }
+
+  /**
+   * @dev set loss rate when swap USD1 to USDC
+   * @param _toUSDCLossRate The loss rate (18 decimals)
+   */
+  function setToUSDCLossRate(uint256 _toUSDCLossRate) external onlyRole(MANAGER) {
+    require(_toUSDCLossRate <= PRECISION, "toUSDCLossRate too high");
+    toUSDCLossRate = _toUSDCLossRate;
+  }
+
+  /**
+   * @dev set loss rate when swap USDC to USD1
+   * @param _toUSD1LossRate The loss rate (18 decimals)
+   */
+  function setToUSD1LossRate(uint256 _toUSD1LossRate) external onlyRole(MANAGER) {
+    require(_toUSD1LossRate <= PRECISION, "toUSD1LossRate too high");
+    toUSD1LossRate = _toUSD1LossRate;
+  }
+
+  /**
+   * @dev get total assets in vault
+   * @return total assets in vault (in USDC)
+   */
+  function getVaultTotalAssets() public view returns (uint256) {
+    uint256 shareTokenShares = IERC20(shareToken).balanceOf(address(this));
+    return IAsyncVault(vault).convertToAssets(shareTokenShares);
+  }
+
+  /**
+   * @dev get conversion from USD1 to USDC
+   * @param amount The amount of USD1 to convert
+   * @return converted amount in USDC
+   */
+  function USD1ToUSDC(uint256 amount) public view returns (uint256) {
+    return amount - amount.mulDiv(toUSDCLossRate, PRECISION);
+  }
+
+  /**
+   * @dev get conversion from USDC to USD1
+   * @param amount The amount of USDC to convert
+   * @return converted amount in USD1
+   */
+  function USDCToUSD1(uint256 amount) public view returns (uint256) {
+    return amount - amount.mulDiv(toUSD1LossRate, PRECISION);
+  }
+
+  /**
+   * @dev allows manager to withdraw reward tokens for emergency or recover any other mistaken ERC20 tokens.
+   * @param token ERC20 token address
+   * @param amount token amount
+   */
+  function emergencyWithdraw(address token, uint256 amount) external onlyRole(MANAGER) {
+    IERC20(token).safeTransfer(msg.sender, amount);
+    emit EmergencyWithdraw(token, amount);
+  }
+
+  /* INTERNAL FUNCTIONS */
+  function _requestDepositToVault(uint256 amountUSDC) private {
+    // approve amount to vault
+    IERC20(USDC).safeIncreaseAllowance(vault, amountUSDC);
+    // request deposit to vault
+    IAsyncVault(vault).requestDeposit(amountUSDC, address(this), address(this));
+
+    emit RequestDepositToVault(amountUSDC);
+  }
+
+  function _updateVaultAssets() private {
+    uint256 newVaultTotalAssets = getVaultTotalAssets();
+    uint256 totalInterest = newVaultTotalAssets - lastVaultTotalAssets;
+
+    // charge fee, asset is USDC
+    uint256 interestFee = totalInterest.mulDiv(feeRate, PRECISION);
+    fee += interestFee;
+
+    // convert to USD1
+    uint256 interest = USDCToUSD1(totalInterest - interestFee);
+
+    // notify interest to earn pool
+    if (interest > 0) {
+      IRWAEarnPool(earnPool).notifyInterest(interest);
+    }
+    // update lastVaultTotalAssets
+    lastVaultTotalAssets = newVaultTotalAssets;
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/src/rwa/RWAAdapter.sol
+++ b/src/rwa/RWAAdapter.sol
@@ -328,22 +328,6 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
     emit EmergencyWithdraw(token, amount);
   }
 
-  /**
-   * @dev claim cancel deposit request from vault
-   */
-  function claimCancelDepositRequest() external onlyRole(BOT) {
-    require(IAsyncVault(vault).claimableCancelDepositRequest(0, address(this)) > 0, "No claimable deposit");
-    IAsyncVault(vault).claimCancelDepositRequest(0, address(this), address(this));
-  }
-
-  /**
-   * @dev claim cancel redeem request from vault
-   */
-  function claimCancelRedeemRequest() external onlyRole(BOT) {
-    require(IAsyncVault(vault).claimableCancelRedeemRequest(0, address(this)) > 0, "No claimable redeem");
-    IAsyncVault(vault).claimCancelRedeemRequest(0, address(this), address(this));
-  }
-
   /* INTERNAL FUNCTIONS */
   function _requestDepositToVault(uint256 amountUSDC) private {
     // approve amount to vault

--- a/src/rwa/RWAEarnPool.sol
+++ b/src/rwa/RWAEarnPool.sol
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract RWAEarnPool is
+  UUPSUpgradeable,
+  AccessControlEnumerableUpgradeable,
+  PausableUpgradeable,
+  ReentrancyGuardUpgradeable
+{
+  using SafeERC20 for IERC20;
+  using Math for uint256;
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  /* STRUCTS */
+  // withdrawal request
+  // batchId: the batch id of the request
+  // withdrawTime: the time of the request
+  // amount: the amount of assets to withdraw
+  struct WithdrawalRequest {
+    uint256 batchId;
+    uint256 withdrawTime;
+    uint256 amount;
+  }
+
+  /* VARIABLES */
+  // user => shares
+  mapping(address => uint256) public balanceOf;
+  // total shares
+  uint256 public totalSupply;
+  // last assets
+  uint256 public userTotalAssets;
+  // asset token address
+  address public asset;
+  // batch id => total withdraw amount
+  mapping(uint256 => uint256) public totalWithdrawAmountInBatch;
+  // User's address => WithdrawalRequest[]
+  mapping(address => WithdrawalRequest[]) private userWithdrawalRequests;
+  // The amount received but not claimable yet
+  uint256 public withdrawQuota;
+  // withdraw fee receiver
+  address public feeReceiver;
+  // withdraw fee rate
+  uint256 public withdrawFeeRate;
+  // period start time
+  uint256 public periodStart;
+  // reward of the current period
+  uint256 public periodRewards;
+  // last epoch day
+  uint256 public lastDay;
+  // current batch id
+  uint256 public currentBatchId;
+  // last confirmed batch id
+  uint256 public confirmedBatchId;
+  // name of the pool
+  string public name;
+  // symbol of the pool
+  string public symbol;
+  // adapter address
+  address public adapter;
+  // deposit whitelist
+  EnumerableSet.AddressSet private whiteList;
+
+  /* constants */
+  bytes32 public constant MANAGER = keccak256("MANAGER"); // manager role
+  bytes32 public constant PAUSER = keccak256("PAUSER"); // pauser role
+  uint256 public constant PRECISION = 1 ether; // precision
+  uint256 constant REWARD_DURATION = 1 weeks; // reward duration is 1 week
+
+  /* EVENTS */
+  event Transfer(address indexed from, address indexed to, uint256 value);
+  event RequestWithdraw(
+    address owner,
+    address receiver,
+    uint256 batchId,
+    uint256 shares,
+    uint256 amount,
+    uint256 feeShares
+  );
+  event FinishWithdraw(uint256 epoch, uint256 amount);
+  event ClaimWithdrawal(address user, uint256 idx, uint256 amount);
+  event Deposit(address indexed user, uint256 amount);
+  event NotifyInterest(uint256 interest);
+  event SetFeeReceiver(address feeReceiver);
+  event SetWithdrawFeeRate(uint256 withdrawFeeRate);
+  event EmergencyWithdraw(address token, uint256 amount);
+
+  /* CONSTRUCTOR */
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /* INITIALIZER */
+  /**
+   * @dev Initialize the contract
+   * @param _admin The address of the admin role
+   * @param _manager The address of the manager role
+   * @param _pauser The address of the pauser role
+   * @param _asset The address of the asset token
+   * @param _name The name of the pool
+   * @param _symbol The symbol of the pool
+   * @param _adapter The address of the adapter
+   */
+  function initialize(
+    address _admin,
+    address _manager,
+    address _pauser,
+    address _asset,
+    string memory _name,
+    string memory _symbol,
+    address _adapter
+  ) public initializer {
+    require(_admin != address(0), "admin address is zero");
+    require(_manager != address(0), "manager address is zero");
+    require(_pauser != address(0), "pauser address is zero");
+    require(_asset != address(0), "asset address is zero");
+    require(bytes(_name).length > 0, "name is empty");
+    require(bytes(_symbol).length > 0, "symbol is empty");
+    require(_adapter != address(0), "adapter address is zero");
+
+    // initialize inherited contracts
+    __AccessControl_init();
+    __Pausable_init();
+    __ReentrancyGuard_init();
+
+    // setup roles
+    _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    _grantRole(MANAGER, _manager);
+    _grantRole(PAUSER, _pauser);
+
+    // setup variables
+    asset = _asset;
+    name = _name;
+    symbol = _symbol;
+    adapter = _adapter;
+  }
+
+  /* EXTERNAL FUNCTIONS */
+  /**
+   * @dev deposit funds to the pool
+   * @param amount The amount of assets to deposit
+   * @param shares The amount of shares to mint
+   * @param receiver The address of the receiver
+   */
+  function deposit(uint256 amount, uint256 shares, address receiver) external whenNotPaused nonReentrant {
+    require(amount > 0 || shares > 0, "amount and shares is zero");
+    require(receiver != address(0), "receiver is zero address");
+    require(isInWhiteList(receiver), "receiver not in whitelist");
+
+    // calculate shares or amount
+    if (amount > 0) {
+      shares = convertToShares(amount);
+    } else {
+      amount = convertToAssets(shares);
+    }
+    // mint shares to user
+    _mint(receiver, shares);
+    userTotalAssets += amount;
+    // transfer asset from user
+    IERC20(asset).safeTransferFrom(msg.sender, adapter, amount);
+
+    emit Deposit(receiver, amount);
+  }
+
+  /**
+   * @dev request withdraw funds from the pool
+   * @param amount The amount of assets to withdraw
+   * @param shares The amount of shares to burn
+   * @param receiver The address of the receiver
+   */
+  function requestWithdraw(uint256 amount, uint256 shares, address receiver) external whenNotPaused nonReentrant {
+    require(amount > 0 || shares > 0, "amount and shares is zero");
+    require(receiver != address(0), "receiver is zero address");
+
+    // calculate shares or amount
+    if (amount > 0) {
+      shares = convertToShares(amount);
+    } else {
+      amount = convertToAssets(shares);
+    }
+
+    require(balanceOf[msg.sender] >= shares, "insufficient shares");
+
+    uint256 feeShares;
+    // charge withdraw fee
+    if (withdrawFeeRate > 0 && feeReceiver != address(0)) {
+      // feeShares =  shares * withdrawFeeRate / PRECISION
+      feeShares = shares.mulDiv(withdrawFeeRate, PRECISION);
+      if (feeShares > 0) {
+        // transfer fee shares to feeReceiver
+        _transfer(msg.sender, feeReceiver, feeShares);
+
+        shares -= feeShares;
+        amount -= convertToAssets(feeShares);
+      }
+    }
+
+    // burn shares from user
+    _burn(msg.sender, shares);
+
+    // if new day, increase batch id
+    // if currentBatchId == confirmedBatchId, increase batch id too
+    uint256 day = block.timestamp / 1 days;
+    if (day > lastDay) {
+      lastDay = day;
+      ++currentBatchId;
+    } else if (currentBatchId == confirmedBatchId) {
+      ++currentBatchId;
+    }
+
+    // add withdraw request to user
+    userWithdrawalRequests[receiver].push(
+      WithdrawalRequest({ batchId: currentBatchId, amount: amount, withdrawTime: block.timestamp })
+    );
+
+    // update total withdraw amount in batch
+    totalWithdrawAmountInBatch[currentBatchId] += amount;
+    // update user total assets
+    userTotalAssets -= amount;
+
+    emit RequestWithdraw(msg.sender, receiver, currentBatchId, shares, amount, feeShares);
+  }
+
+  /**
+   * @dev finish withdraw funds from the pool
+   * @param amount The amount of assets to finish withdraw
+   */
+  function finishWithdraw(uint256 amount) external {
+    require(msg.sender == adapter, "only adapter can call");
+    require(amount > 0, "amount is zero");
+
+    // update withdraw quota
+    withdrawQuota += amount;
+
+    // cover withdraw requests in batch
+    for (uint256 i = confirmedBatchId + 1; i <= currentBatchId; i++) {
+      uint256 withdrawAmount = totalWithdrawAmountInBatch[i];
+      // if withdraw amount cannot be covered, break
+      if (withdrawAmount > withdrawQuota) {
+        break;
+      }
+      // cover withdraw requests in batch
+      confirmedBatchId = i;
+      withdrawQuota -= withdrawAmount;
+      emit FinishWithdraw(confirmedBatchId, withdrawAmount);
+    }
+
+    // transfer asset from adapter
+    IERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
+  }
+
+  /**
+   * @dev claim withdraw funds from the pool
+   * @param user The address of the user
+   * @param idx The index of the withdraw request
+   */
+  function claimWithdraw(address user, uint256 idx) external whenNotPaused nonReentrant {
+    WithdrawalRequest[] storage userRequests = userWithdrawalRequests[user];
+
+    // check index
+    require(idx < userRequests.length, "Invalid index");
+    WithdrawalRequest memory withdrawRequest = userRequests[idx];
+
+    // check if the request can be claimed
+    require(withdrawRequest.batchId <= confirmedBatchId, "Not able to claim yet");
+
+    // move the last request to the current index
+    userRequests[idx] = userRequests[userRequests.length - 1];
+    userRequests.pop();
+
+    // transfer asset to user
+    IERC20(asset).safeTransfer(user, withdrawRequest.amount);
+
+    emit ClaimWithdrawal(user, idx, withdrawRequest.amount);
+  }
+
+  /**
+   * @dev notify interest to the pool
+   * @param amount The amount of interest
+   */
+  function notifyInterest(uint256 amount) external {
+    require(msg.sender == adapter, "only adapter can call");
+
+    // update user total assets
+    userTotalAssets = totalAssets();
+
+    // update period rewards and period start
+    periodRewards = getUnvestAmount() + amount;
+    periodStart = block.timestamp;
+
+    emit NotifyInterest(amount);
+  }
+
+  /**
+   * @dev get unvest amount
+   * @return The amount of unvest
+   */
+  function getUnvestAmount() public view returns (uint256) {
+    // if no rewards or period finished, return 0
+    if (block.timestamp >= periodStart + REWARD_DURATION) {
+      return 0;
+    }
+
+    // unvest = (periodFinish - block.timestamp) * periodRewards / REWARD_DURATION
+    uint256 duration = periodStart + REWARD_DURATION - block.timestamp;
+    return duration.mulDiv(periodRewards, REWARD_DURATION);
+  }
+
+  /**
+   * @dev convert assets to shares
+   * @param assets The amount of assets to convert
+   * @return The amount of shares
+   */
+  function convertToShares(uint256 assets) public view returns (uint256) {
+    // if no shares or no assets, return assets
+    if (totalSupply == 0 || totalAssets() == 0) {
+      return assets;
+    }
+    // shares = assets * totalSupply / totalAssets
+    return assets.mulDiv(totalSupply, totalAssets());
+  }
+
+  /**
+   * @dev convert shares to assets
+   * @param shares The amount of shares to convert
+   * @return The amount of assets
+   */
+  function convertToAssets(uint256 shares) public view returns (uint256) {
+    // if no shares or no assets, return shares
+    if (totalSupply == 0 || totalAssets() == 0) {
+      return shares;
+    }
+    // assets = shares * totalAssets / totalSupply
+    return shares.mulDiv(totalAssets(), totalSupply);
+  }
+
+  /**
+   * @dev get total assets of the pool
+   * @return The amount of total assets
+   */
+  function totalAssets() public view returns (uint256) {
+    // total assets = userTotalAssets + periodRewards - getUnvestAmount()
+    return userTotalAssets + periodRewards - getUnvestAmount();
+  }
+
+  /**
+   * @dev get claimable request indexes of a user
+   * @param user The address of the user
+   * @return The indexes of the claimable requests
+   */
+  function getClaimableRequestIndexes(address user) external view returns (uint256[] memory) {
+    WithdrawalRequest[] storage userRequests = userWithdrawalRequests[user];
+    uint256 count = 0;
+    // count claimable requests
+    for (uint256 i = 0; i < userRequests.length; i++) {
+      if (userRequests[i].batchId <= confirmedBatchId) {
+        count++;
+      }
+    }
+
+    uint256[] memory indexes = new uint256[](count);
+    uint256 idx = 0;
+    // get claimable request indexes
+    for (uint256 i = 0; i < userRequests.length; i++) {
+      if (userRequests[i].batchId <= confirmedBatchId) {
+        indexes[idx] = i;
+        idx++;
+      }
+    }
+    return indexes;
+  }
+
+  function getUserWithdrawalRequests(address user) external view returns (WithdrawalRequest[] memory) {
+    return userWithdrawalRequests[user];
+  }
+
+  /**
+   * @dev check if a user is in the whitelist
+   * @param user The address of the user
+   * @return True if the user is in the whitelist, false otherwise
+   */
+  function isInWhiteList(address user) public view returns (bool) {
+    return whiteList.length() == 0 || whiteList.contains(user);
+  }
+
+  /**
+   * @dev get the whitelist
+   * @return The addresses in the whitelist
+   */
+  function getWhiteList() external view returns (address[] memory) {
+    return whiteList.values();
+  }
+
+  /* ADMIN FUNCTIONS */
+  /**
+   * @dev set withdraw fee rate
+   * @param _withdrawFeeRate The withdraw fee rate
+   */
+  function setWithdrawFeeRate(uint256 _withdrawFeeRate) external onlyRole(MANAGER) {
+    require(_withdrawFeeRate <= PRECISION, "withdraw fee rate too high");
+    require(withdrawFeeRate != _withdrawFeeRate, "same withdraw fee rate");
+    withdrawFeeRate = _withdrawFeeRate;
+
+    emit SetWithdrawFeeRate(_withdrawFeeRate);
+  }
+
+  /**
+   * @dev set fee receiver
+   * @param _feeReceiver The address of the fee receiver
+   */
+  function setFeeReceiver(address _feeReceiver) external onlyRole(MANAGER) {
+    require(_feeReceiver != address(0), "fee receiver is zero address");
+    require(feeReceiver != _feeReceiver, "same fee receiver");
+    feeReceiver = _feeReceiver;
+
+    emit SetFeeReceiver(_feeReceiver);
+  }
+
+  /**
+   * @dev set whitelist status of a user
+   * @param user The address of the user
+   * @param ok True to add to whitelist, false to remove from whitelist
+   */
+  function setWhiteList(address user, bool ok) external onlyRole(MANAGER) {
+    require(user != address(0), "user is zero address");
+    require(whiteList.contains(user) != ok, "same status");
+    if (ok) {
+      whiteList.add(user);
+    } else {
+      whiteList.remove(user);
+    }
+  }
+
+  /**
+   * @dev allows manager to withdraw reward tokens for emergency or recover any other mistaken ERC20 tokens.
+   * @param token ERC20 token address
+   * @param amount token amount
+   */
+  function emergencyWithdraw(address token, uint256 amount) external onlyRole(MANAGER) {
+    IERC20(token).safeTransfer(msg.sender, amount);
+    emit EmergencyWithdraw(token, amount);
+  }
+
+  /* INTERNAL FUNCTIONS */
+  function _mint(address account, uint256 amount) internal {
+    require(account != address(0), "mint to the zero address");
+
+    balanceOf[account] += amount;
+    totalSupply += amount;
+
+    emit Transfer(address(0), account, amount);
+  }
+
+  function _burn(address account, uint256 amount) internal {
+    require(account != address(0), "burn from the zero address");
+    require(balanceOf[account] >= amount, "burn amount exceeds balance");
+
+    balanceOf[account] -= amount;
+    totalSupply -= amount;
+
+    emit Transfer(account, address(0), amount);
+  }
+
+  function _transfer(address from, address to, uint256 amount) internal {
+    require(from != address(0), "transfer from the zero address");
+    require(to != address(0), "transfer to the zero address");
+    require(balanceOf[from] >= amount, "transfer amount exceeds balance");
+
+    balanceOf[from] -= amount;
+    balanceOf[to] += amount;
+
+    emit Transfer(from, to, amount);
+  }
+
+  /**
+   * @dev pause contract
+   */
+  function pause() external onlyRole(PAUSER) {
+    _pause();
+  }
+
+  /**
+   * @dev unpause contract
+   */
+  function unpause() external onlyRole(MANAGER) {
+    _unpause();
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/src/rwa/interface/IAsyncVault.sol
+++ b/src/rwa/interface/IAsyncVault.sol
@@ -12,4 +12,22 @@ interface IAsyncVault {
   function maxRedeem(address account) external view returns (uint256);
   function mint(uint256 shares, address receiver) external returns (uint256);
   function redeem(uint256 shares, address receiver, address owner) external returns (uint256);
+  function claimCancelDepositRequest(
+    uint256 requestId,
+    address receiver,
+    address controller
+  ) external returns (uint256 assets);
+  function claimCancelRedeemRequest(
+    uint256 requestId,
+    address receiver,
+    address controller
+  ) external returns (uint256 shares);
+  function claimableCancelDepositRequest(
+    uint256 requestId,
+    address controller
+  ) external view returns (uint256 claimableAssets);
+  function claimableCancelRedeemRequest(
+    uint256 requestId,
+    address controller
+  ) external view returns (uint256 claimableShares);
 }

--- a/src/rwa/interface/IAsyncVault.sol
+++ b/src/rwa/interface/IAsyncVault.sol
@@ -12,22 +12,4 @@ interface IAsyncVault {
   function maxRedeem(address account) external view returns (uint256);
   function mint(uint256 shares, address receiver) external returns (uint256);
   function redeem(uint256 shares, address receiver, address owner) external returns (uint256);
-  function claimCancelDepositRequest(
-    uint256 requestId,
-    address receiver,
-    address controller
-  ) external returns (uint256 assets);
-  function claimCancelRedeemRequest(
-    uint256 requestId,
-    address receiver,
-    address controller
-  ) external returns (uint256 shares);
-  function claimableCancelDepositRequest(
-    uint256 requestId,
-    address controller
-  ) external view returns (uint256 claimableAssets);
-  function claimableCancelRedeemRequest(
-    uint256 requestId,
-    address controller
-  ) external view returns (uint256 claimableShares);
 }

--- a/src/rwa/interface/IAsyncVault.sol
+++ b/src/rwa/interface/IAsyncVault.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IAsyncVault {
+  function totalAssets() external view returns (uint256);
+  function convertToShares(uint256 assets) external view returns (uint256);
+  function convertToAssets(uint256 shares) external view returns (uint256);
+  function balanceOf(address account) external view returns (uint256);
+  function requestDeposit(uint256 assets, address controller, address owner) external returns (uint256);
+  function requestRedeem(uint256 shares, address controller, address owner) external returns (uint256);
+  function maxMint(address account) external view returns (uint256);
+  function maxRedeem(address account) external view returns (uint256);
+  function mint(uint256 shares, address receiver) external returns (uint256);
+  function redeem(uint256 shares, address receiver, address owner) external returns (uint256);
+}

--- a/src/rwa/interface/IOTCManager.sol
+++ b/src/rwa/interface/IOTCManager.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IOTCManager {
+  function swapToken(address token, uint256 amount) external;
+}

--- a/src/rwa/interface/IRWAEarnPool.sol
+++ b/src/rwa/interface/IRWAEarnPool.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IRWAEarnPool {
+  function withdrawFromVault() external;
+  function finishWithdraw(uint256 amount) external;
+  function requestDepositToVault(uint256 amount) external;
+  function notifyInterest(uint256 amount) external;
+}

--- a/src/rwa/interface/IRWAEarnPool.sol
+++ b/src/rwa/interface/IRWAEarnPool.sol
@@ -6,4 +6,6 @@ interface IRWAEarnPool {
   function finishWithdraw(uint256 amount) external;
   function requestDepositToVault(uint256 amount) external;
   function notifyInterest(uint256 amount) external;
+  function totalSupply() external view returns (uint256);
+  function totalAssets() external view returns (uint256);
 }

--- a/test/rwa/OTCManager.t.sol
+++ b/test/rwa/OTCManager.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../src/rwa/RWAEarnPool.sol";
+import "../../src/rwa/RWAAdapter.sol";
+import "../../src/mock/MockAsyncVault.sol";
+import "../../src/mock/MockERC20.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "../../src/rwa/OTCManager.sol";
+
+contract OTCManagerTest is Test {
+  MockERC20 USD1;
+  MockERC20 USDC;
+  OTCManager otcManager;
+
+  address admin;
+  address manager;
+  address bot;
+  address adapter;
+  address otcWallet;
+  function setUp() public {
+    USD1 = new MockERC20("USD1", "USD1");
+    USDC = new MockERC20("USDC", "USDC");
+
+    admin = makeAddr("admin");
+    manager = makeAddr("manager");
+    bot = makeAddr("bot");
+    adapter = makeAddr("adapter");
+    otcWallet = makeAddr("otcWallet");
+
+    OTCManager otcManagerImpl = new OTCManager(address(USD1), address(USDC));
+    otcManager = OTCManager(
+      address(
+        new ERC1967Proxy(
+          address(otcManagerImpl),
+          abi.encodeWithSelector(otcManagerImpl.initialize.selector, admin, manager, bot, adapter, otcWallet)
+        )
+      )
+    );
+  }
+
+  function test_swapToken() public {
+    USD1.mint(adapter, 1 ether);
+    USDC.mint(adapter, 1 ether);
+
+    vm.startPrank(adapter);
+    USD1.approve(address(otcManager), 1 ether);
+    otcManager.swapToken(address(USD1), 1 ether);
+    vm.stopPrank();
+
+    assertEq(USD1.balanceOf(adapter), 0, "adapter USD1 balance");
+    assertEq(USD1.balanceOf(otcWallet), 1 ether, "otcWallet USD1 balance");
+
+    vm.startPrank(adapter);
+    USDC.approve(address(otcManager), 1 ether);
+    otcManager.swapToken(address(USDC), 1 ether);
+    vm.stopPrank();
+
+    assertEq(USDC.balanceOf(adapter), 0, "adapter USDC balance");
+    assertEq(USDC.balanceOf(otcWallet), 1 ether, "otcWallet USDC balance");
+  }
+
+  function test_transferToAdapter() public {
+    USD1.mint(address(otcManager), 1 ether);
+    USDC.mint(address(otcManager), 1 ether);
+
+    vm.startPrank(bot);
+    otcManager.transferToAdapter(address(USD1), 1 ether);
+    vm.stopPrank();
+
+    assertEq(USD1.balanceOf(address(otcManager)), 0, "otcManager USD1 balance");
+    assertEq(USD1.balanceOf(adapter), 1 ether, "adapter USD1 balance");
+
+    vm.startPrank(bot);
+    otcManager.transferToAdapter(address(USDC), 1 ether);
+    vm.stopPrank();
+
+    assertEq(USDC.balanceOf(address(otcManager)), 0, "otcManager USDC balance");
+    assertEq(USDC.balanceOf(adapter), 1 ether, "adapter USDC balance");
+  }
+}

--- a/test/rwa/RWAAdapter.t.sol
+++ b/test/rwa/RWAAdapter.t.sol
@@ -280,43 +280,6 @@ contract RWAAdapterTest is Test {
     assertEq(earnPool.periodRewards(), 1 ether, "earnPool periodRewards");
   }
 
-  function test_claimCancelDepositRequest() public {
-    USDC.mint(address(vault), 1 ether);
-
-    vault.setClaimableAssets(1 ether);
-    assertEq(vault.claimableAssets(), 1 ether, "vault claimableAssets");
-    assertEq(
-      vault.claimableCancelDepositRequest(0, address(adapter)),
-      1 ether,
-      "vault claimableCancelDepositRequest return value"
-    );
-
-    vm.startPrank(bot);
-    adapter.claimCancelDepositRequest();
-    vm.stopPrank();
-
-    assertEq(USDC.balanceOf(address(adapter)), 1 ether, "adapter USDC balance after claim");
-    assertEq(USDC.balanceOf(address(vault)), 0, "vault USDC balance after claim");
-  }
-
-  function test_claimCancelRedeemRequest() public {
-    shareToken.mint(address(vault), 1 ether);
-
-    vault.setClaimableAssets(1 ether);
-    assertEq(
-      vault.claimableCancelRedeemRequest(0, address(adapter)),
-      1 ether,
-      "vault claimableCancelRedeemRequest return value"
-    );
-
-    vm.startPrank(bot);
-    adapter.claimCancelRedeemRequest();
-    vm.stopPrank();
-
-    assertEq(shareToken.balanceOf(address(adapter)), 1 ether, "adapter shareToken balance after claim");
-    assertEq(shareToken.balanceOf(address(vault)), 0, "vault shareToken balance after claim");
-  }
-
   function test_newAssetLessThanOldAsset() public {
     USDC.mint(address(adapter), 1 ether);
 

--- a/test/rwa/RWAAdapter.t.sol
+++ b/test/rwa/RWAAdapter.t.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../src/rwa/RWAEarnPool.sol";
+import "../../src/rwa/RWAAdapter.sol";
+import "../../src/mock/MockAsyncVault.sol";
+import "../../src/mock/MockERC20.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "../../src/rwa/OTCManager.sol";
+
+contract RWAAdapterTest is Test {
+  MockERC20 USD1;
+  MockERC20 USDC;
+  MockERC20 shareToken;
+  RWAAdapter adapter;
+  RWAEarnPool earnPool;
+  OTCManager otcManager;
+  MockAsyncVault vault;
+
+  address admin;
+  address manager;
+  address pauser;
+  address bot;
+  address user;
+  address otcWallet;
+  address feeReceiver;
+
+  function setUp() public {
+    admin = makeAddr("admin");
+    user = makeAddr("user");
+    manager = makeAddr("manager");
+    pauser = makeAddr("pauser");
+    bot = makeAddr("bot");
+    otcWallet = makeAddr("otcWallet");
+    feeReceiver = makeAddr("feeReceiver");
+
+    USD1 = new MockERC20("USD1", "USD1");
+    USDC = new MockERC20("USDC", "USDC");
+    shareToken = new MockERC20("mUSD1", "mUSD1");
+
+    vault = new MockAsyncVault(address(USDC), address(shareToken), 1e18);
+
+    RWAEarnPool earnPoolImpl = new RWAEarnPool();
+    RWAAdapter adapterImpl = new RWAAdapter(address(USD1), address(USDC));
+    OTCManager otcManagerImpl = new OTCManager(address(USD1), address(USDC));
+
+    earnPool = RWAEarnPool(address(new ERC1967Proxy(address(earnPoolImpl), "")));
+
+    adapter = RWAAdapter(address(new ERC1967Proxy(address(adapterImpl), "")));
+
+    otcManager = OTCManager(address(new ERC1967Proxy(address(otcManagerImpl), "")));
+
+    earnPool.initialize(admin, manager, pauser, address(USD1), "USD1.Treasury", "USD1.Treasury", address(adapter));
+
+    adapter.initialize(
+      admin,
+      manager,
+      bot,
+      address(earnPool),
+      address(otcManager),
+      address(vault),
+      address(shareToken)
+    );
+
+    otcManager.initialize(admin, manager, bot, address(adapter), otcWallet);
+  }
+
+  function test_requestDepositToVault() public {
+    USDC.mint(address(adapter), 1 ether);
+
+    vm.startPrank(bot);
+    adapter.requestDepositToVault(1 ether);
+    vm.stopPrank();
+
+    assertEq(USDC.balanceOf(address(adapter)), 0, "adapter USDC balance");
+    assertEq(USDC.balanceOf(address(vault)), 1 ether, "vault USDC balance");
+  }
+
+  function test_depositToVault() public {
+    USDC.mint(address(adapter), 1 ether);
+
+    vm.startPrank(bot);
+    adapter.requestDepositToVault(1 ether);
+    adapter.depositToVault();
+    vm.stopPrank();
+
+    assertEq(USDC.balanceOf(address(adapter)), 0, "adapter USDC balance");
+    assertEq(USDC.balanceOf(address(vault)), 1 ether, "vault USDC balance");
+    assertEq(shareToken.balanceOf(address(adapter)), 1 ether, "adapter shareToken balance");
+  }
+
+  function test_depositRewards() public {
+    USD1.mint(user, 1 ether);
+    USDC.mint(manager, 1 ether);
+    USDC.mint(address(adapter), 1 ether);
+
+    vm.startPrank(user);
+    USD1.approve(address(earnPool), 1 ether);
+    earnPool.deposit(1 ether, 0, user);
+    vm.stopPrank();
+
+    vm.startPrank(manager);
+    USDC.approve(address(adapter), 1 ether);
+    adapter.depositRewards(1 ether);
+    vm.stopPrank();
+
+    vm.startPrank(bot);
+    adapter.requestDepositToVault(1 ether);
+    adapter.depositToVault();
+    vm.stopPrank();
+
+    skip(7 days);
+    assertEq(earnPool.totalAssets(), 2 ether, "earnPool totalAssets");
+    assertEq(shareToken.balanceOf(address(adapter)), 2 ether, "adapter shareToken balance");
+  }
+
+  function test_requestWithdrawFromVault() public {
+    USDC.mint(address(adapter), 1 ether);
+
+    vm.startPrank(bot);
+    adapter.requestDepositToVault(1 ether);
+    adapter.depositToVault();
+    adapter.requestWithdrawFromVault(0.5 ether);
+    vm.stopPrank();
+
+    assertEq(USDC.balanceOf(address(adapter)), 0, "adapter USDC balance");
+    assertEq(USDC.balanceOf(address(vault)), 1 ether, "vault USDC balance");
+    assertEq(shareToken.balanceOf(address(adapter)), 0.5 ether, "adapter shareToken balance");
+  }
+
+  function test_withdrawFromVault() public {
+    USDC.mint(address(adapter), 1 ether);
+
+    vm.startPrank(bot);
+    adapter.requestDepositToVault(1 ether);
+    adapter.depositToVault();
+    adapter.requestWithdrawFromVault(1 ether);
+    adapter.withdrawFromVault(false);
+    vm.stopPrank();
+
+    assertEq(USDC.balanceOf(address(adapter)), 1 ether, "adapter USDC balance");
+    assertEq(USDC.balanceOf(address(vault)), 0, "vault USDC balance");
+    assertEq(shareToken.balanceOf(address(adapter)), 0, "adapter shareToken balance");
+
+    USDC.mint(address(vault), 1 ether);
+
+    vm.startPrank(manager);
+    adapter.setFeeReceiver(feeReceiver);
+    adapter.setFeeRate(0.1 ether);
+    vm.stopPrank();
+
+    vm.startPrank(bot);
+    adapter.requestDepositToVault(1 ether);
+    adapter.depositToVault();
+
+    vault.setConvertRate(2 ether);
+
+    adapter.requestWithdrawFromVault(2 ether);
+    adapter.withdrawFromVault(true);
+    vm.stopPrank();
+
+    assertEq(USDC.balanceOf(address(adapter)), 1.9 ether, "adapter USDC balance after fee");
+    assertEq(USDC.balanceOf(feeReceiver), 0.1 ether, "feeReceiver USDC balance after fee");
+    assertEq(USDC.balanceOf(address(vault)), 0, "vault USDC balance after fee");
+    assertEq(shareToken.balanceOf(address(adapter)), 0, "adapter shareToken balance after fee");
+  }
+
+  function test_finishEarnPoolWithdraw() public {
+    USD1.mint(user, 1 ether);
+    vm.startPrank(user);
+    USD1.approve(address(earnPool), 1 ether);
+    earnPool.deposit(1 ether, 0, user);
+    earnPool.requestWithdraw(1 ether, 0, user);
+    vm.stopPrank();
+
+    vm.startPrank(bot);
+    adapter.finishEarnPoolWithdraw(1 ether);
+    vm.stopPrank();
+
+    assertEq(USD1.balanceOf(address(earnPool)), 1 ether, "earnPool USD1 balance");
+    assertEq(earnPool.confirmedBatchId(), 1, "earnPool confirmedBatchId");
+    assertEq(USD1.balanceOf(address(adapter)), 0, "adapter USD1 balance");
+  }
+
+  function test_swapToken() public {
+    USD1.mint(address(adapter), 1 ether);
+    USDC.mint(address(adapter), 1 ether);
+
+    vm.startPrank(bot);
+    adapter.swapToken(address(USD1), 1 ether);
+    adapter.swapToken(address(USDC), 1 ether);
+    vm.stopPrank();
+
+    assertEq(USD1.balanceOf(address(adapter)), 0, "adapter USD1 balance");
+    assertEq(USDC.balanceOf(address(adapter)), 0, "adapter USDC balance");
+    assertEq(USD1.balanceOf(otcWallet), 1 ether, "otcWallet USD1 balance");
+    assertEq(USDC.balanceOf(otcWallet), 1 ether, "otcWallet USDC balance");
+  }
+
+  function test_updateVaultAssets() public {
+    USDC.mint(address(adapter), 1 ether);
+    USD1.mint(user, 1 ether);
+
+    vm.startPrank(user);
+    USD1.approve(address(earnPool), 1 ether);
+    earnPool.deposit(1 ether, 0, user);
+    vm.stopPrank();
+
+    vm.startPrank(bot);
+    adapter.requestDepositToVault(1 ether);
+    adapter.depositToVault();
+    vm.stopPrank();
+
+    vault.setConvertRate(1.1 ether);
+
+    vm.startPrank(bot);
+    adapter.updateVaultAssets();
+    vm.stopPrank();
+
+    assertEq(adapter.lastVaultTotalAssets(), 1.1 ether, "adapter vaultAssets");
+    assertEq(earnPool.totalAssets(), 1 ether, "earnPool totalAssets");
+
+    skip(7 days);
+    assertEq(earnPool.totalAssets(), 1.1 ether, "earnPool totalAssets after 7 days");
+  }
+
+  function test_setToUSDCLossRate() public {
+    vm.startPrank(manager);
+    adapter.setToUSDCLossRate(0.05 ether);
+    vm.stopPrank();
+
+    assertEq(adapter.toUSDCLossRate(), 0.05 ether, "toUSDCLossRate");
+    assertEq(adapter.USD1ToUSDC(1 ether), 0.95 ether, "USD1ToUSDC");
+  }
+
+  function test_setToUSD1LossRate() public {
+    vm.startPrank(manager);
+    adapter.setToUSD1LossRate(0.05 ether);
+    vm.stopPrank();
+
+    assertEq(adapter.toUSD1LossRate(), 0.05 ether, "toUSD1LossRate");
+    assertEq(adapter.USDCToUSD1(1 ether), 0.95 ether, "USDCToUSD1");
+  }
+}

--- a/test/rwa/RWAAdapter.t.sol
+++ b/test/rwa/RWAAdapter.t.sol
@@ -53,15 +53,7 @@ contract RWAAdapterTest is Test {
 
     earnPool.initialize(admin, manager, pauser, address(USD1), "USD1.Treasury", "USD1.Treasury", address(adapter));
 
-    adapter.initialize(
-      admin,
-      manager,
-      bot,
-      address(earnPool),
-      address(otcManager),
-      address(vault),
-      address(shareToken)
-    );
+    adapter.initialize(admin, manager, bot, address(earnPool), address(vault), address(shareToken));
 
     otcManager.initialize(admin, manager, bot, address(adapter), otcWallet);
   }
@@ -188,6 +180,15 @@ contract RWAAdapterTest is Test {
     USDC.mint(address(adapter), 1 ether);
 
     vm.startPrank(bot);
+    vm.expectRevert("otcManager is zero address");
+    adapter.swapToken(address(USDC), 1 ether);
+    vm.stopPrank();
+
+    vm.startPrank(manager);
+    adapter.setOTCManager(address(otcManager));
+    vm.stopPrank();
+
+    vm.startPrank(bot);
     adapter.swapToken(address(USD1), 1 ether);
     adapter.swapToken(address(USDC), 1 ether);
     vm.stopPrank();
@@ -225,22 +226,22 @@ contract RWAAdapterTest is Test {
     assertEq(earnPool.totalAssets(), 1.1 ether, "earnPool totalAssets after 7 days");
   }
 
-  function test_setToUSDCLossRate() public {
+  function test_setToVaultAssetLossRate() public {
     vm.startPrank(manager);
-    adapter.setToUSDCLossRate(0.05 ether);
+    adapter.setToVaultAssetLossRate(0.05 ether);
     vm.stopPrank();
 
-    assertEq(adapter.toUSDCLossRate(), 0.05 ether, "toUSDCLossRate");
-    assertEq(adapter.USD1ToUSDC(1 ether), 0.95 ether, "USD1ToUSDC");
+    assertEq(adapter.toVaultAssetLossRate(), 0.05 ether, "toVaultAssetLossRate");
+    assertEq(adapter.AssetToVaultAsset(1 ether), 0.95 ether, "AssetToVaultAsset");
   }
 
   function test_setToUSD1LossRate() public {
     vm.startPrank(manager);
-    adapter.setToUSD1LossRate(0.05 ether);
+    adapter.setToAssetLossRate(0.05 ether);
     vm.stopPrank();
 
-    assertEq(adapter.toUSD1LossRate(), 0.05 ether, "toUSD1LossRate");
-    assertEq(adapter.USDCToUSD1(1 ether), 0.95 ether, "USDCToUSD1");
+    assertEq(adapter.toAssetLossRate(), 0.05 ether, "toAssetLossRate");
+    assertEq(adapter.VaultAssetToAsset(1 ether), 0.95 ether, "VaultAssetToAsset");
   }
 
   function test_depositRewardsBeforeDepositToVault() public {

--- a/test/rwa/RWAEarnPool.t.sol
+++ b/test/rwa/RWAEarnPool.t.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../src/rwa/RWAEarnPool.sol";
+import "../../src/mock/MockAsyncVault.sol";
+import "../../src/mock/MockERC20.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract RWAEarnPoolTest is Test {
+  RWAEarnPool earnPool;
+  MockERC20 USD1;
+  address admin;
+  address manager;
+  address pauser;
+  address adapter;
+  address user;
+  address feeReceiver;
+
+  function setUp() public {
+    admin = makeAddr("admin");
+    user = makeAddr("user");
+    manager = makeAddr("manager");
+    pauser = makeAddr("pauser");
+    adapter = makeAddr("adapter");
+    USD1 = new MockERC20("USD1", "USD1");
+    feeReceiver = makeAddr("feeReceiver");
+
+    RWAEarnPool impl = new RWAEarnPool();
+    earnPool = RWAEarnPool(
+      address(
+        new ERC1967Proxy(
+          address(impl),
+          abi.encodeWithSelector(
+            impl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            address(USD1),
+            "USD1.Treasury",
+            "USD1.Treasury",
+            adapter
+          )
+        )
+      )
+    );
+  }
+
+  function test_depositWithAmount() public {
+    USD1.mint(user, 1 ether);
+
+    depositToEarnPool(user, 1 ether);
+
+    assertEq(USD1.balanceOf(user), 0, "user USD1 balance");
+    assertEq(earnPool.balanceOf(user), 1 ether, "user earnPool shares");
+    assertEq(USD1.balanceOf(adapter), 1 ether, "adapter USD1 balance");
+  }
+
+  function test_depositWithShares() public {
+    USD1.mint(user, 1 ether);
+
+    depositToEarnPool(user, 1 ether);
+
+    assertEq(USD1.balanceOf(user), 0, "user USD1 balance");
+    assertEq(earnPool.balanceOf(user), 1 ether, "user earnPool shares");
+    assertEq(USD1.balanceOf(adapter), 1 ether, "adapter USD1 balance");
+  }
+
+  function test_requestWithdraw() public {
+    USD1.mint(user, 1 ether);
+
+    depositToEarnPool(user, 1 ether);
+
+    vm.startPrank(user);
+    earnPool.requestWithdraw(1 ether, 0, user);
+    vm.stopPrank();
+
+    assertEq(earnPool.balanceOf(user), 0, "user earnPool shares after requestWithdraw");
+
+    RWAEarnPool.WithdrawalRequest[] memory requests = earnPool.getUserWithdrawalRequests(user);
+
+    assertEq(requests.length, 1, "user withdrawal requests length");
+    assertEq(requests[0].amount, 1 ether, "user withdrawal request shares");
+  }
+
+  function test_finishWithdraw() public {
+    USD1.mint(user, 1 ether);
+
+    depositToEarnPool(user, 1 ether);
+
+    vm.startPrank(user);
+    earnPool.requestWithdraw(0.5 ether, 0, user);
+    vm.stopPrank();
+
+    vm.startPrank(adapter);
+    USD1.approve(address(earnPool), type(uint256).max);
+    earnPool.finishWithdraw(0.5 ether);
+    vm.stopPrank();
+
+    assertEq(USD1.balanceOf(address(earnPool)), 0.5 ether, "earnPool USD1 balance after finishWithdraw");
+    assertEq(USD1.balanceOf(adapter), 0.5 ether, "adapter USD1 balance after finishWithdraw");
+    assertEq(earnPool.confirmedBatchId(), 1, "earnPool confirmedBatchId after finishWithdraw");
+
+    uint256[] memory claimableIndexes = earnPool.getClaimableRequestIndexes(user);
+    assertEq(claimableIndexes.length, 1, "user claimable request indexes length");
+    assertEq(claimableIndexes[0], 0, "user claimable request indexs");
+
+    vm.startPrank(user);
+    earnPool.requestWithdraw(0.5 ether, 0, user);
+    vm.stopPrank();
+
+    vm.startPrank(adapter);
+    earnPool.finishWithdraw(0.5 ether);
+    vm.stopPrank();
+
+    assertEq(USD1.balanceOf(address(earnPool)), 1 ether, "earnPool USD1 balance after finishWithdraw");
+    assertEq(USD1.balanceOf(adapter), 0 ether, "adapter USD1 balance after finishWithdraw");
+    assertEq(earnPool.confirmedBatchId(), 2, "earnPool confirmedBatchId after finishWithdraw");
+
+    claimableIndexes = earnPool.getClaimableRequestIndexes(user);
+    assertEq(claimableIndexes.length, 2, "user claimable request indexes length");
+    assertEq(claimableIndexes[0], 0, "user claimable request indexs");
+    assertEq(claimableIndexes[1], 1, "user claimable request indexs");
+  }
+
+  function test_claimWithdraw() public {
+    USD1.mint(user, 1 ether);
+
+    depositToEarnPool(user, 1 ether);
+
+    vm.startPrank(user);
+    earnPool.requestWithdraw(1 ether, 0, user);
+    vm.stopPrank();
+
+    vm.startPrank(adapter);
+    USD1.approve(address(earnPool), type(uint256).max);
+    earnPool.finishWithdraw(1 ether);
+    vm.stopPrank();
+
+    vm.startPrank(user);
+    earnPool.claimWithdraw(user, 0);
+    vm.stopPrank();
+
+    assertEq(USD1.balanceOf(user), 1 ether, "user USD1 balance after claimWithdraw");
+    assertEq(earnPool.balanceOf(user), 0, "user earnPool shares after claimWithdraw");
+    assertEq(USD1.balanceOf(address(earnPool)), 0, "earnPool USD1 balance after claimWithdraw");
+
+    RWAEarnPool.WithdrawalRequest[] memory requests = earnPool.getUserWithdrawalRequests(user);
+    assertEq(requests.length, 0, "user withdrawal requests length");
+    uint256[] memory claimableIndexes = earnPool.getClaimableRequestIndexes(user);
+    assertEq(claimableIndexes.length, 0, "user claimable request indexes length");
+  }
+
+  function test_notifyInterest() public {
+    USD1.mint(user, 1 ether);
+
+    depositToEarnPool(user, 1 ether);
+
+    vm.startPrank(adapter);
+    earnPool.notifyInterest(0.7 ether);
+    vm.stopPrank();
+
+    skip(1 days);
+    assertEq(earnPool.totalAssets(), 1.1 ether, "earnPool totalAssets after notifyInterest 1 days");
+    assertEq(earnPool.getUnvestAmount(), 0.6 ether, "earnPool unvestAmount after notifyInterest 1 days");
+
+    skip(7 days);
+    assertEq(earnPool.totalAssets(), 1.7 ether, "earnPool totalAssets after notifyInterest 7 days");
+    assertEq(earnPool.getUnvestAmount(), 0, "earnPool unvestAmount after notifyInterest 7 days");
+
+    skip(8 days);
+    assertEq(earnPool.totalAssets(), 1.7 ether, "earnPool totalAssets after notifyInterest 8 days");
+    assertEq(earnPool.getUnvestAmount(), 0, "earnPool unvestAmount after notifyInterest 8 days");
+  }
+
+  function test_setWhitelist() public {
+    USD1.mint(user, 1 ether);
+    USD1.mint(address(this), 1 ether);
+
+    vm.startPrank(manager);
+    earnPool.setWhiteList(user, true);
+    vm.stopPrank();
+
+    depositToEarnPool(user, 1 ether);
+
+    USD1.approve(address(earnPool), type(uint256).max);
+    vm.expectRevert("receiver not in whitelist");
+    earnPool.deposit(1 ether, 0, address(this));
+
+    address[] memory whitelists = earnPool.getWhiteList();
+    assertEq(whitelists.length, 1, "whitelist length");
+    assertEq(whitelists[0], user, "whitelist address");
+    assertEq(earnPool.isInWhiteList(user), true, "is user in whitelist");
+  }
+
+  function test_fee() public {
+    USD1.mint(user, 1 ether);
+
+    depositToEarnPool(user, 1 ether);
+
+    vm.startPrank(manager);
+    earnPool.setWithdrawFeeRate(0.1 ether); // 10%
+    earnPool.setFeeReceiver(feeReceiver);
+    vm.stopPrank();
+
+    vm.startPrank(user);
+    earnPool.requestWithdraw(1 ether, 0, user);
+    vm.stopPrank();
+
+    assertEq(earnPool.balanceOf(user), 0, "user earnPool shares after requestWithdraw");
+    assertEq(earnPool.balanceOf(feeReceiver), 0.1 ether, "feeReceiver earnPool shares after requestWithdraw");
+
+    RWAEarnPool.WithdrawalRequest[] memory requests = earnPool.getUserWithdrawalRequests(user);
+    assertEq(requests[0].amount, 0.9 ether, "user withdrawal request shares after fee");
+  }
+
+  function depositToEarnPool(address _user, uint256 amount) private {
+    vm.startPrank(_user);
+    USD1.approve(address(earnPool), type(uint256).max);
+    earnPool.deposit(1 ether, 0, _user);
+    vm.stopPrank();
+  }
+}

--- a/test/rwa/RWAEarnPool.t.sol
+++ b/test/rwa/RWAEarnPool.t.sol
@@ -101,10 +101,6 @@ contract RWAEarnPoolTest is Test {
     assertEq(USD1.balanceOf(adapter), 0.5 ether, "adapter USD1 balance after finishWithdraw");
     assertEq(earnPool.confirmedBatchId(), 1, "earnPool confirmedBatchId after finishWithdraw");
 
-    uint256[] memory claimableIndexes = earnPool.getClaimableRequestIndexes(user);
-    assertEq(claimableIndexes.length, 1, "user claimable request indexes length");
-    assertEq(claimableIndexes[0], 0, "user claimable request indexs");
-
     vm.startPrank(user);
     earnPool.requestWithdraw(0.5 ether, 0, user);
     vm.stopPrank();
@@ -116,11 +112,6 @@ contract RWAEarnPoolTest is Test {
     assertEq(USD1.balanceOf(address(earnPool)), 1 ether, "earnPool USD1 balance after finishWithdraw");
     assertEq(USD1.balanceOf(adapter), 0 ether, "adapter USD1 balance after finishWithdraw");
     assertEq(earnPool.confirmedBatchId(), 2, "earnPool confirmedBatchId after finishWithdraw");
-
-    claimableIndexes = earnPool.getClaimableRequestIndexes(user);
-    assertEq(claimableIndexes.length, 2, "user claimable request indexes length");
-    assertEq(claimableIndexes[0], 0, "user claimable request indexs");
-    assertEq(claimableIndexes[1], 1, "user claimable request indexs");
   }
 
   function test_claimWithdraw() public {
@@ -147,8 +138,6 @@ contract RWAEarnPoolTest is Test {
 
     RWAEarnPool.WithdrawalRequest[] memory requests = earnPool.getUserWithdrawalRequests(user);
     assertEq(requests.length, 0, "user withdrawal requests length");
-    uint256[] memory claimableIndexes = earnPool.getClaimableRequestIndexes(user);
-    assertEq(claimableIndexes.length, 0, "user claimable request indexes length");
   }
 
   function test_notifyInterest() public {
@@ -162,15 +151,15 @@ contract RWAEarnPoolTest is Test {
 
     skip(1 days);
     assertEq(earnPool.totalAssets(), 1.1 ether, "earnPool totalAssets after notifyInterest 1 days");
-    assertEq(earnPool.getUnvestAmount(), 0.6 ether, "earnPool unvestAmount after notifyInterest 1 days");
+    assertEq(earnPool.getUnvestedAmount(), 0.6 ether, "earnPool unvestAmount after notifyInterest 1 days");
 
     skip(7 days);
     assertEq(earnPool.totalAssets(), 1.7 ether, "earnPool totalAssets after notifyInterest 7 days");
-    assertEq(earnPool.getUnvestAmount(), 0, "earnPool unvestAmount after notifyInterest 7 days");
+    assertEq(earnPool.getUnvestedAmount(), 0, "earnPool unvestAmount after notifyInterest 7 days");
 
     skip(8 days);
     assertEq(earnPool.totalAssets(), 1.7 ether, "earnPool totalAssets after notifyInterest 8 days");
-    assertEq(earnPool.getUnvestAmount(), 0, "earnPool unvestAmount after notifyInterest 8 days");
+    assertEq(earnPool.getUnvestedAmount(), 0, "earnPool unvestAmount after notifyInterest 8 days");
   }
 
   function test_setWhitelist() public {
@@ -190,7 +179,7 @@ contract RWAEarnPoolTest is Test {
     address[] memory whitelists = earnPool.getWhiteList();
     assertEq(whitelists.length, 1, "whitelist length");
     assertEq(whitelists[0], user, "whitelist address");
-    assertEq(earnPool.isInWhiteList(user), true, "is user in whitelist");
+    assertEq(earnPool.isInWhitelist(user), true, "is user in whitelist");
   }
 
   function test_fee() public {


### PR DESCRIPTION
## 📄 Description
The contract for RWA investment has been added, supporting investments in RWA assets using USD1.

1. RWAEarnPool is used to handle user deposits, withdrawals, and the distribution of earnings.
2. RWAAdapter is used to interact with the Centrifuge vault. It converts the USD 1 deposited into the RWAEarnPool into USDC and deposits it into the vault. It also handles withdrawal requests from the RWAEarnPool, batch-extracting USDC from the vault, converting it back to USD1, and returning it to the RWAEarnPool to finish user withdrawal requests.
3. OTCManager is used for the mutual exchange between USD 1 and USDC.

## 🧠 Rationale



## 🧪 Example / Testing
 forge test --match-contract RWAEarnPoolTest -vvvv
 forge test --match-contract RWAAdapterTest -vvvv
 forge test --match-contract OTCManagerTest -vvvv

## 🧬 Changes Summary
* add new contracts src/rwa/*
