### PR TITLE
feat: replace withdrawFromVault(bool) with withdrawFromVault(uint256 feeAmount)

### DIFF
--- a/script/rwa/deploy_rwaAdapter_impl.s.sol
+++ b/script/rwa/deploy_rwaAdapter_impl.s.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+
+import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import { Options } from "openzeppelin-foundry-upgrades/Options.sol";
+
+import "../../src/rwa/RWAAdapter.sol";
+
+contract DeployRWAAdapterImplScript is Script {
+  // BSC Mainnet USDT
+  address public constant USDT = 0x55d398326f99059fF775485246999027B3197955;
+
+  /**
+   * @dev Deploy a new RWAAdapter implementation for upgrade
+   *
+   * Usage:
+   * DEPLOYER_PRIVATE_KEY=<key> BSCSCAN_API_KEY=<key> \
+   *   forge script script/rwa/deploy_rwaAdapter_impl.s.sol:DeployRWAAdapterImplScript \
+   *   --rpc-url https://bsc-dataseed.binance.org \
+   *   --etherscan-api-key <bscscan-api-key> \
+   *   --broadcast --verify -vvv
+   */
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: %s", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy new implementation with same constructor args as the original
+    // Both asset and vaultAsset are USDT for the current RWAAdapter deployments
+    RWAAdapter newImpl = new RWAAdapter(USDT, USDT);
+    console.log("New RWAAdapter implementation: %s", address(newImpl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/rwa/RWAAdapter.sol
+++ b/src/rwa/RWAAdapter.sol
@@ -187,9 +187,9 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
 
   /**
    * @dev finish withdraw request and redeem vault asset from vault
-   * @param claimFee Whether to claim the accumulated fee
+   * @param feeAmount The fee amount to claim, should be the fee value snapshot taken at requestWithdrawFromVault time
    */
-  function withdrawFromVault(bool claimFee) external onlyRole(BOT) {
+  function withdrawFromVault(uint256 feeAmount) external onlyRole(BOT) {
     // get max redeem amount from vault
     uint256 maxRedeem = IAsyncVault(vault).maxRedeem(address(this));
     // require max redeem amount > 0
@@ -200,15 +200,14 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
     IAsyncVault(vault).redeem(maxRedeem, address(this), address(this));
     uint256 totalAmount = IERC20(vaultAsset).balanceOf(address(this)) - before;
 
-    uint256 feeAmount;
-    if (claimFee && fee > 0) {
+    if (feeAmount > 0) {
       require(feeReceiver != address(0), "feeReceiver is zero");
-      require(totalAmount >= fee, "totalAmount < fee");
+      require(fee >= feeAmount, "feeAmount exceeds accumulated fee");
+      require(totalAmount >= feeAmount, "totalAmount < feeAmount");
 
       // transfer fee to feeReceiver
-      IERC20(vaultAsset).safeTransfer(feeReceiver, fee);
-      feeAmount = fee;
-      fee = 0;
+      IERC20(vaultAsset).safeTransfer(feeReceiver, feeAmount);
+      fee -= feeAmount;
     }
 
     emit WithdrawFromVault(maxRedeem, totalAmount, feeAmount);

--- a/test/rwa/RWAAdapter.t.sol
+++ b/test/rwa/RWAAdapter.t.sol
@@ -128,7 +128,7 @@ contract RWAAdapterTest is Test {
     adapter.requestDepositToVault(1 ether);
     adapter.depositToVault();
     adapter.requestWithdrawFromVault(1 ether);
-    adapter.withdrawFromVault(false);
+    adapter.withdrawFromVault(0);
     vm.stopPrank();
 
     assertEq(USDC.balanceOf(address(adapter)), 1 ether, "adapter USDC balance");
@@ -149,7 +149,9 @@ contract RWAAdapterTest is Test {
     vault.setConvertRate(2 ether);
 
     adapter.requestWithdrawFromVault(2 ether);
-    adapter.withdrawFromVault(true);
+    // use fee snapshot taken at requestWithdrawFromVault time
+    uint256 feeSnapshot = adapter.fee();
+    adapter.withdrawFromVault(feeSnapshot);
     vm.stopPrank();
 
     assertEq(USDC.balanceOf(address(adapter)), 1.9 ether, "adapter USDC balance after fee");


### PR DESCRIPTION
## Summary

- Replace `withdrawFromVault(bool claimFee)` with `withdrawFromVault(uint256 feeAmount)`
- Bot passes the fee snapshot taken at `requestWithdrawFromVault` time instead of the real-time `fee` state variable
- Use partial deduction `fee -= feeAmount` instead of resetting `fee = 0`

## Problem

The original `withdrawFromVault(bool claimFee)` used the current real-time `fee` value at redeem time. Since fee accumulates daily, by the time the vault actually redeems, `fee` has grown beyond the amount reserved at request time, causing `totalAmount < fee` to revert and delaying user withdrawals.

## Solution

The bot records the `fee` snapshot after calling `requestWithdrawFromVault`, then passes it into `withdrawFromVault(feeSnapshot)`, ensuring each redeem only claims the fee corresponding to that specific batch.

## Test plan

- [x] `test_withdrawFromVault` — covers both `feeAmount=0` and `feeAmount=snapshot` cases, all passing
