### PR TITLE
feat: RWA min thresholds + allow zero amount in finishWithdraw

### DIFF
--- a/script/rwa/deploy_rwaEarnPool_impl.s.sol
+++ b/script/rwa/deploy_rwaEarnPool_impl.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+
+import "../../src/rwa/RWAEarnPool.sol";
+
+contract DeployRWAEarnPoolImplScript is Script {
+  /**
+   * @dev Deploy a new RWAEarnPool implementation for upgrade
+   *
+   * Usage:
+   * DEPLOYER_PRIVATE_KEY=<key> BSCSCAN_API_KEY=<key> \
+   *   forge script script/rwa/deploy_rwaEarnPool_impl.s.sol:DeployRWAEarnPoolImplScript \
+   *   --rpc-url https://bsc-dataseed.binance.org \
+   *   --etherscan-api-key <bscscan-api-key> \
+   *   --broadcast --verify -vvv
+   */
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: %s", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    RWAEarnPool newImpl = new RWAEarnPool();
+    console.log("New RWAEarnPool implementation: %s", address(newImpl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/rwa/RWAAdapter.sol
+++ b/src/rwa/RWAAdapter.sol
@@ -36,6 +36,10 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   uint256 public fee;
   // last total assets in vault
   uint256 public lastVaultTotalAssets;
+  // minimum amount for requestDepositToVault, in vaultAsset units
+  uint256 public minDeposit;
+  // minimum amount for requestWithdrawFromVault, in vaultAsset units
+  uint256 public minWithdraw;
 
   /* CONSTANTS */
   bytes32 public constant MANAGER = keccak256("MANAGER");
@@ -58,6 +62,8 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   event SetFeeRate(uint256 feeRate);
   event SetToVaultAssetLossRate(uint256 toVaultAssetLossRate);
   event SetToAssetLossRate(uint256 toAssetLossRate);
+  event SetMinDeposit(uint256 minDeposit);
+  event SetMinWithdraw(uint256 minWithdraw);
 
   /* CONSTRUCTOR */
   /// @custom:oz-upgrades-unsafe-allow constructor
@@ -117,6 +123,7 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
    */
   function requestDepositToVault(uint256 amountVaultAsset) external onlyRole(BOT) {
     require(amountVaultAsset > 0, "Amount amountVaultAsset be greater than zero");
+    require(amountVaultAsset >= minDeposit, "below min deposit");
     _requestDepositToVault(amountVaultAsset);
   }
 
@@ -167,6 +174,7 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
    */
   function requestWithdrawFromVault(uint256 amountVaultAsset) external onlyRole(BOT) {
     require(amountVaultAsset > 0, "Amount must be greater than zero");
+    require(amountVaultAsset >= minWithdraw, "below min withdraw");
     // update vault assets and charge fee
     _updateVaultAssets();
 
@@ -291,6 +299,26 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
   function setOTCManager(address _otcManager) external onlyRole(MANAGER) {
     require(_otcManager != address(0), "otcManager is zero address");
     otcManager = _otcManager;
+  }
+
+  /**
+   * @dev set minimum amount for requestDepositToVault
+   * @param _minDeposit The minimum amount, in vaultAsset units
+   */
+  function setMinDeposit(uint256 _minDeposit) external onlyRole(MANAGER) {
+    require(minDeposit != _minDeposit, "same minDeposit");
+    minDeposit = _minDeposit;
+    emit SetMinDeposit(_minDeposit);
+  }
+
+  /**
+   * @dev set minimum amount for requestWithdrawFromVault
+   * @param _minWithdraw The minimum amount, in vaultAsset units
+   */
+  function setMinWithdraw(uint256 _minWithdraw) external onlyRole(MANAGER) {
+    require(minWithdraw != _minWithdraw, "same minWithdraw");
+    minWithdraw = _minWithdraw;
+    emit SetMinWithdraw(_minWithdraw);
   }
 
   /**

--- a/src/rwa/RWAAdapter.sol
+++ b/src/rwa/RWAAdapter.sol
@@ -226,8 +226,9 @@ contract RWAAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
    * @param amountAsset The amount of asset to cover withdraw
    */
   function finishEarnPoolWithdraw(uint256 amountAsset) external onlyRole(BOT) {
-    require(amountAsset > 0, "Amount must be greater than zero");
-    IERC20(asset).safeIncreaseAllowance(earnPool, amountAsset);
+    if (amountAsset > 0) {
+      IERC20(asset).safeIncreaseAllowance(earnPool, amountAsset);
+    }
     IRWAEarnPool(earnPool).finishWithdraw(amountAsset);
   }
 

--- a/src/rwa/RWAEarnPool.sol
+++ b/src/rwa/RWAEarnPool.sol
@@ -69,6 +69,8 @@ contract RWAEarnPool is
   address public adapter;
   // deposit whitelist
   EnumerableSet.AddressSet private whitelist;
+  // minimum deposit amount, in asset units
+  uint256 public minDeposit;
 
   /* constants */
   bytes32 public constant MANAGER = keccak256("MANAGER"); // manager role
@@ -95,6 +97,7 @@ contract RWAEarnPool is
   event SetWithdrawFeeRate(uint256 withdrawFeeRate);
   event EmergencyWithdraw(address token, uint256 amount);
   event WhiteListChanged(address user, bool ok);
+  event SetMinDeposit(uint256 minDeposit);
 
   /* CONSTRUCTOR */
   /// @custom:oz-upgrades-unsafe-allow constructor
@@ -167,6 +170,7 @@ contract RWAEarnPool is
     }
 
     require(shares > 0, "shares is zero");
+    require(amount >= minDeposit, "deposit below minimum");
 
     // mint shares to user
     _mint(receiver, shares);
@@ -433,6 +437,16 @@ contract RWAEarnPool is
     }
 
     emit WhiteListChanged(user, ok);
+  }
+
+  /**
+   * @dev set minimum deposit amount
+   * @param _minDeposit The minimum deposit amount, in asset units
+   */
+  function setMinDeposit(uint256 _minDeposit) external onlyRole(MANAGER) {
+    require(minDeposit != _minDeposit, "same minDeposit");
+    minDeposit = _minDeposit;
+    emit SetMinDeposit(_minDeposit);
   }
 
   /**

--- a/src/rwa/RWAEarnPool.sol
+++ b/src/rwa/RWAEarnPool.sol
@@ -252,13 +252,12 @@ contract RWAEarnPool is
    */
   function finishWithdraw(uint256 amount) external {
     require(msg.sender == adapter, "only adapter can call");
-    require(amount > 0, "amount is zero");
 
-    // transfer asset from adapter
-    IERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
-
-    // update withdraw quota
-    withdrawQuota += amount;
+    // transfer asset from adapter (zero allowed: lets BOT tick batches without adding funds)
+    if (amount > 0) {
+      IERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
+      withdrawQuota += amount;
+    }
 
     // cover withdraw requests in batch
     for (uint256 i = confirmedBatchId + 1; i <= currentBatchId; i++) {

--- a/test/rwa/RWAAdapter.t.sol
+++ b/test/rwa/RWAAdapter.t.sol
@@ -177,6 +177,25 @@ contract RWAAdapterTest is Test {
     assertEq(USD1.balanceOf(address(adapter)), 0, "adapter USD1 balance");
   }
 
+  function test_finishEarnPoolWithdraw_zeroAmount() public {
+    // user deposits and requests withdraw
+    USD1.mint(user, 1 ether);
+    vm.startPrank(user);
+    USD1.approve(address(earnPool), 1 ether);
+    earnPool.deposit(1 ether, 0, user);
+    earnPool.requestWithdraw(1 ether, 0, user);
+    vm.stopPrank();
+
+    // adapter has surplus assets and ticks batch with non-zero call first
+    vm.startPrank(bot);
+    adapter.finishEarnPoolWithdraw(1 ether);
+    // calling with 0 must succeed (no further batches but should not revert)
+    adapter.finishEarnPoolWithdraw(0);
+    vm.stopPrank();
+
+    assertEq(earnPool.confirmedBatchId(), 1, "earnPool confirmedBatchId");
+  }
+
   function test_swapToken() public {
     USD1.mint(address(adapter), 1 ether);
     USDC.mint(address(adapter), 1 ether);

--- a/test/rwa/RWAAdapter.t.sol
+++ b/test/rwa/RWAAdapter.t.sol
@@ -283,6 +283,98 @@ contract RWAAdapterTest is Test {
     assertEq(earnPool.periodRewards(), 1 ether, "earnPool periodRewards");
   }
 
+  function test_setMinDeposit_onlyManager() public {
+    vm.expectRevert();
+    adapter.setMinDeposit(1000 ether);
+
+    vm.startPrank(manager);
+    vm.expectEmit(false, false, false, true);
+    emit RWAAdapter.SetMinDeposit(1000 ether);
+    adapter.setMinDeposit(1000 ether);
+    assertEq(adapter.minDeposit(), 1000 ether, "minDeposit");
+
+    vm.expectRevert("same minDeposit");
+    adapter.setMinDeposit(1000 ether);
+    vm.stopPrank();
+  }
+
+  function test_setMinWithdraw_onlyManager() public {
+    vm.expectRevert();
+    adapter.setMinWithdraw(1000 ether);
+
+    vm.startPrank(manager);
+    vm.expectEmit(false, false, false, true);
+    emit RWAAdapter.SetMinWithdraw(1000 ether);
+    adapter.setMinWithdraw(1000 ether);
+    assertEq(adapter.minWithdraw(), 1000 ether, "minWithdraw");
+
+    vm.expectRevert("same minWithdraw");
+    adapter.setMinWithdraw(1000 ether);
+    vm.stopPrank();
+  }
+
+  function test_requestDepositToVault_revertsBelowMin() public {
+    vm.startPrank(manager);
+    adapter.setMinDeposit(1000 ether);
+    vm.stopPrank();
+
+    USDC.mint(address(adapter), 2000 ether);
+
+    vm.startPrank(bot);
+    vm.expectRevert("below min deposit");
+    adapter.requestDepositToVault(999 ether);
+
+    // boundary: equal to min passes
+    adapter.requestDepositToVault(1000 ether);
+    vm.stopPrank();
+
+    assertEq(USDC.balanceOf(address(vault)), 1000 ether, "vault USDC balance");
+  }
+
+  function test_requestWithdrawFromVault_revertsBelowMin() public {
+    USDC.mint(address(adapter), 2000 ether);
+
+    vm.startPrank(bot);
+    adapter.requestDepositToVault(2000 ether);
+    adapter.depositToVault();
+    vm.stopPrank();
+
+    vm.startPrank(manager);
+    adapter.setMinWithdraw(1000 ether);
+    vm.stopPrank();
+
+    vm.startPrank(bot);
+    vm.expectRevert("below min withdraw");
+    adapter.requestWithdrawFromVault(999 ether);
+
+    // boundary: equal to min passes
+    adapter.requestWithdrawFromVault(1000 ether);
+    vm.stopPrank();
+  }
+
+  function test_depositRewards_unaffectedByMin() public {
+    // ensure earn pool has shares so depositRewards passes its precondition
+    USD1.mint(user, 1 ether);
+    vm.startPrank(user);
+    USD1.approve(address(earnPool), 1 ether);
+    earnPool.deposit(1 ether, 0, user);
+    vm.stopPrank();
+
+    // set a high min that would block any direct BOT deposit
+    vm.startPrank(manager);
+    adapter.setMinDeposit(1000 ether);
+    vm.stopPrank();
+
+    // depositRewards path internally calls _requestDepositToVault but should not be gated
+    USDC.mint(manager, 1 ether);
+    vm.startPrank(manager);
+    USDC.approve(address(adapter), 1 ether);
+    adapter.depositRewards(1 ether);
+    vm.stopPrank();
+
+    assertEq(earnPool.periodRewards(), 1 ether, "periodRewards");
+  }
+
   function test_newAssetLessThanOldAsset() public {
     USDC.mint(address(adapter), 1 ether);
 

--- a/test/rwa/RWAEarnPool.t.sol
+++ b/test/rwa/RWAEarnPool.t.sol
@@ -114,6 +114,38 @@ contract RWAEarnPoolTest is Test {
     assertEq(earnPool.confirmedBatchId(), 2, "earnPool confirmedBatchId after finishWithdraw");
   }
 
+  function test_finishWithdraw_zeroAmount_ticksBatchesUsingExistingQuota() public {
+    USD1.mint(user, 2 ether);
+    depositToEarnPool(user, 2 ether);
+
+    // request 1: 0.5
+    vm.startPrank(user);
+    earnPool.requestWithdraw(0.5 ether, 0, user);
+    vm.stopPrank();
+
+    // first finishWithdraw with surplus quota that covers req1 + builds 0.5 leftover
+    vm.startPrank(adapter);
+    USD1.approve(address(earnPool), type(uint256).max);
+    earnPool.finishWithdraw(1 ether);
+    vm.stopPrank();
+    assertEq(earnPool.confirmedBatchId(), 1, "first batch confirmed");
+    assertEq(earnPool.withdrawQuota(), 0.5 ether, "leftover quota");
+
+    // request 2 in a new batch — needs 0.5 which leftover quota can cover
+    vm.warp(block.timestamp + 1 days);
+    vm.startPrank(user);
+    earnPool.requestWithdraw(0.5 ether, 0, user);
+    vm.stopPrank();
+
+    // calling with 0 must NOT revert and must tick batch 2 using leftover quota
+    vm.startPrank(adapter);
+    earnPool.finishWithdraw(0);
+    vm.stopPrank();
+
+    assertEq(earnPool.confirmedBatchId(), 2, "batch 2 confirmed via zero call");
+    assertEq(earnPool.withdrawQuota(), 0, "quota fully consumed");
+  }
+
   function test_claimWithdraw() public {
     USD1.mint(user, 1 ether);
 

--- a/test/rwa/RWAEarnPool.t.sol
+++ b/test/rwa/RWAEarnPool.t.sol
@@ -245,6 +245,67 @@ contract RWAEarnPoolTest is Test {
     assertEq(earnPool.balanceOf(user), 0, "user earnPool shares after requestWithdraw");
   }
 
+  function test_setMinDeposit_onlyManager() public {
+    vm.expectRevert();
+    earnPool.setMinDeposit(1000 ether);
+
+    vm.startPrank(manager);
+    vm.expectEmit(false, false, false, true);
+    emit RWAEarnPool.SetMinDeposit(1000 ether);
+    earnPool.setMinDeposit(1000 ether);
+    assertEq(earnPool.minDeposit(), 1000 ether, "minDeposit");
+
+    vm.expectRevert("same minDeposit");
+    earnPool.setMinDeposit(1000 ether);
+    vm.stopPrank();
+  }
+
+  function test_deposit_revertsBelowMin_byAmount() public {
+    vm.startPrank(manager);
+    earnPool.setMinDeposit(1000 ether);
+    vm.stopPrank();
+
+    USD1.mint(user, 2000 ether);
+
+    vm.startPrank(user);
+    USD1.approve(address(earnPool), type(uint256).max);
+    vm.expectRevert("deposit below minimum");
+    earnPool.deposit(999 ether, 0, user);
+
+    // boundary: equal to min passes
+    earnPool.deposit(1000 ether, 0, user);
+    vm.stopPrank();
+
+    assertEq(earnPool.balanceOf(user), 1000 ether, "user shares");
+  }
+
+  function test_deposit_revertsBelowMin_byShares() public {
+    // first seed pool with one large deposit so shares-based path has meaningful conversion
+    USD1.mint(user, 2000 ether);
+    depositToEarnPool(user, 2000 ether);
+
+    vm.startPrank(manager);
+    earnPool.setMinDeposit(1000 ether);
+    vm.stopPrank();
+
+    address other = makeAddr("other");
+    USD1.mint(other, 2000 ether);
+
+    vm.startPrank(other);
+    USD1.approve(address(earnPool), type(uint256).max);
+    // 999 shares -> ~999 amount, below min, must revert (proves shares path is also gated)
+    vm.expectRevert("deposit below minimum");
+    earnPool.deposit(0, 999 ether, other);
+    vm.stopPrank();
+  }
+
+  function test_deposit_zeroMin_backwardCompat() public {
+    // default minDeposit == 0, small deposits still allowed
+    USD1.mint(user, 1);
+    depositToEarnPool(user, 1);
+    assertEq(earnPool.balanceOf(user), 1, "user shares");
+  }
+
   function test_withdrawAllFee() public {
     USD1.mint(user, 1 ether);
 


### PR DESCRIPTION
## Summary

Two related changes to the RWA contracts:

1. **Minimum amount thresholds** — adds configurable lower bounds for `RWAEarnPool.deposit` (user-facing) and `RWAAdapter.requestDepositToVault` / `requestWithdrawFromVault` (BOT vault operations). Defaults to `0` so the upgrade is a no-op until manager calls the setters.
2. **Zero amount allowed in finish-withdraw paths** — `RWAEarnPool.finishWithdraw` and `RWAAdapter.finishEarnPoolWithdraw` now accept `0`, letting the BOT tick already-funded batches without sending more assets.

## Change type

- [ ] New contract
- [x] Upgrade (existing proxy)
- [ ] Bug fix
- [ ] Gas optimization
- [x] Configuration change
- [ ] Migration / deploy script
- [x] Test
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| `RWAEarnPool` | `src/rwa/RWAEarnPool.sol` | modified |
| `RWAAdapter` | `src/rwa/RWAAdapter.sol` | modified |

## Interface changes

**`RWAEarnPool`**
- New state: `uint256 public minDeposit`
- New event: `SetMinDeposit(uint256 minDeposit)`
- New function: `setMinDeposit(uint256 _minDeposit) onlyRole(MANAGER)`
- `deposit` now reverts with `"deposit below minimum"` when the resolved asset amount is less than `minDeposit`. Check is placed after `convertToShares` / `convertToAssets`, so both `amount`-path and `shares`-path entries are gated.
- `finishWithdraw` no longer reverts on `amount == 0`. Transfer + `withdrawQuota +=` are skipped when `amount == 0`; the batch-advancement loop still runs and can confirm batches using leftover quota from prior calls.

**`RWAAdapter`**
- New state: `uint256 public minDeposit`, `uint256 public minWithdraw` (both in `vaultAsset` units)
- New events: `SetMinDeposit(uint256)`, `SetMinWithdraw(uint256)`
- New functions: `setMinDeposit`, `setMinWithdraw` (both `onlyRole(MANAGER)`)
- `requestDepositToVault` reverts with `"below min deposit"` when `amountVaultAsset < minDeposit`
- `requestWithdrawFromVault` reverts with `"below min withdraw"` when `amountVaultAsset < minWithdraw`
- `depositRewards` is **intentionally not gated** — it calls the private `_requestDepositToVault` directly so reward distributions can be of any size.
- `finishEarnPoolWithdraw` no longer reverts on `amountAsset == 0`. The `safeIncreaseAllowance` call is skipped at zero, and `IRWAEarnPool.finishWithdraw` is forwarded the zero amount unchanged.

## Storage layout

Verified via `forge inspect storage-layout`:

**`RWAEarnPool`** — new variable appended at slot 19 (after `whitelist` which occupies slots 17–18):
```
slot 17–18: whitelist (EnumerableSet.AddressSet, 64 bytes)
slot 19:    minDeposit (uint256)   <-- NEW
```

**`RWAAdapter`** — new variables appended at slots 10 and 11:
```
slot 9:  lastVaultTotalAssets (existing)
slot 10: minDeposit (uint256)   <-- NEW
slot 11: minWithdraw (uint256)  <-- NEW
```

No reordering, no removals, no `__gap` impact. Storage layout is upgrade-safe.

## Access control

Unchanged for all existing functions. Three new setters (`setMinDeposit` on both contracts, `setMinWithdraw` on adapter) are all `onlyRole(MANAGER)`, consistent with other configuration setters. The relaxed `finishWithdraw` / `finishEarnPoolWithdraw` keep their existing `msg.sender == adapter` and `onlyRole(BOT)` gates respectively — only the input-validation check changed, not authorization.

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | New vars appended at end of layout for both contracts; verified via `forge inspect storage-layout` |
| Fund safety | 🟢 None | Only adds lower-bound checks and relaxes a zero-amount check (zero transfers cannot move funds); no changes to share math, asset transfers, fee logic, or vault interactions |
| Access control | 🟢 None | New setters use existing `MANAGER` role; relaxed checks preserve their original `adapter`/`BOT` gates |
| External call safety | 🟢 None | Zero-amount path explicitly skips `safeTransferFrom` / `safeIncreaseAllowance` so problematic ERC20 implementations that revert on zero are not invoked |

## Deployment

Post-merge requires:
1. Deploy new implementations for `RWAEarnPool` and `RWAAdapter`
2. UUPS-upgrade both proxies via existing admin path (timelock / multisig)
3. Manager calls (only needed once thresholds are required):
   - `RWAEarnPool.setMinDeposit(1000 * 10**assetDecimals)`
   - `RWAAdapter.setMinDeposit(1000 * 10**vaultAssetDecimals)`
   - `RWAAdapter.setMinWithdraw(1000 * 10**vaultAssetDecimals)`

Default `0` after upgrade keeps deposit/withdraw behavior identical to current production until step 3 lands. The zero-amount finish-withdraw relaxation takes effect immediately on upgrade — no setter required. No new env vars. Upgrade script not yet added — can be done as a follow-up using the existing `deploy_rwaAdapter_impl.s.sol` template.

## Test plan

- [x] `forge test` — full suite passes (90 tests, 0 failing)
- [x] `forge build` — clean compile
- [x] New tests added (11 total):
  - `RWAEarnPool`:
    - `test_setMinDeposit_onlyManager` — access control + emit + same-value revert
    - `test_deposit_revertsBelowMin_byAmount` — below-min via `amount` path + boundary
    - `test_deposit_revertsBelowMin_byShares` — below-min via `shares` path (anti-bypass)
    - `test_deposit_zeroMin_backwardCompat` — default 0 keeps small deposits working
    - `test_finishWithdraw_zeroAmount_ticksBatchesUsingExistingQuota` — zero call advances new batch using leftover quota
  - `RWAAdapter`:
    - `test_setMinDeposit_onlyManager` / `test_setMinWithdraw_onlyManager` — access control + emit + same-value revert
    - `test_requestDepositToVault_revertsBelowMin` — sub-min revert + boundary
    - `test_requestWithdrawFromVault_revertsBelowMin` — sub-min revert + boundary
    - `test_depositRewards_unaffectedByMin` — regression: reward path bypasses gate
    - `test_finishEarnPoolWithdraw_zeroAmount` — zero call no-op succeeds
- [x] Storage layout verified upgrade-safe via `forge inspect`
- [ ] Validate upgrade via OZ upgrades plugin on testnet before mainnet upgrade
- [ ] Testnet smoke: deposit/withdraw at min boundary, sub-min revert, reward distribution under high min, zero-amount finishWithdraw ticking pending batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)