### PR TITLE
fix: lisAster Sherlock May 7th audit findings (#6, #10)

### DIFF
--- a/src/lisaster/LisAsterDistributor.sol
+++ b/src/lisaster/LisAsterDistributor.sol
@@ -167,7 +167,11 @@ contract LisAsterDistributor is
 
   /// @notice Tune the time-lock window. Admin-only. Floored at `MIN_WAITING_PERIOD` so that
   ///         MANAGER's revoke window can never be configured below the safety threshold.
+  ///         Disallowed while a pending root is in flight: otherwise lowering the window
+  ///         would implicitly shrink MANAGER's veto time on the currently staged root.
+  ///         If the admin needs to change the period mid-flight, revoke the pending root first.
   function changeWaitingPeriod(uint256 newWaitingPeriod) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(pendingMerkleRoot == bytes32(0), "pending root exists");
     require(newWaitingPeriod >= MIN_WAITING_PERIOD, "waitingPeriod too short");
     waitingPeriod = newWaitingPeriod;
     emit WaitingPeriodUpdated(newWaitingPeriod);
@@ -227,6 +231,7 @@ contract LisAsterDistributor is
     uint256 already = claimed[account];
     require(cumulativeAmount > already, "nothing to claim");
     payable_ = cumulativeAmount - already;
+    require(totalClaimed + payable_ <= totalAllocated, "exceeds allocated");
     claimed[account] = cumulativeAmount;
     totalClaimed += payable_;
   }

--- a/test/lisAster/LisAsterDistributor.t.sol
+++ b/test/lisAster/LisAsterDistributor.t.sol
@@ -218,6 +218,45 @@ contract LisAsterDistributorTest is LisAsterBase {
     distributor.changeWaitingPeriod(2 days);
   }
 
+  /// @dev Lowering `waitingPeriod` while a root is pending would retroactively shrink MANAGER's
+  ///      veto window on that in-flight root. Disallow the change until the pending root clears.
+  function test_changeWaitingPeriod_revertsWhilePending() public {
+    _injectNotified(5 ether);
+    uint256 minPeriod = distributor.MIN_WAITING_PERIOD();
+
+    // Stage a root with the default 6h timelock.
+    vm.prank(bot);
+    distributor.setPendingMerkleRoot(_singleLeafRoot(user, 5 ether), 5 ether);
+
+    // Admin tries to retune the window — must revert while a pending root exists.
+    vm.prank(admin);
+    vm.expectRevert(bytes("pending root exists"));
+    distributor.changeWaitingPeriod(minPeriod);
+  }
+
+  function test_changeWaitingPeriod_allowedAfterAccept() public {
+    _injectNotified(5 ether);
+    _setLiveMerkleRoot(_singleLeafRoot(user, 5 ether), 5 ether); // accepts + clears pending
+
+    vm.prank(admin);
+    distributor.changeWaitingPeriod(2 days);
+    assertEq(distributor.waitingPeriod(), 2 days);
+  }
+
+  function test_changeWaitingPeriod_allowedAfterRevoke() public {
+    _injectNotified(5 ether);
+    vm.prank(bot);
+    distributor.setPendingMerkleRoot(_singleLeafRoot(user, 5 ether), 5 ether);
+
+    vm.prank(manager);
+    distributor.revokePendingMerkleRoot();
+
+    // After revoke, pendingMerkleRoot is zero again → admin can retune freely.
+    vm.prank(admin);
+    distributor.changeWaitingPeriod(2 days);
+    assertEq(distributor.waitingPeriod(), 2 days);
+  }
+
   function test_initialize_revertsBelowMinWaitingPeriod() public {
     LisAsterDistributor freshImpl = new LisAsterDistributor();
     LisAsterDistributor fresh = LisAsterDistributor(address(new ERC1967Proxy(address(freshImpl), "")));
@@ -281,6 +320,35 @@ contract LisAsterDistributorTest is LisAsterBase {
     wrongProof[0] = bytes32(uint256(0xdeadbeef));
     vm.expectRevert(bytes("invalid proof"));
     distributor.claim(user, 4 ether, wrongProof);
+  }
+
+  /// @dev Defense-in-depth: even if BOT stages a root whose leaves exceed the declared
+  ///      `totalAllocated`, `_consume()` must cap payouts at `totalAllocated` and revert.
+  function test_claim_revertsExceedsAllocated() public {
+    _injectNotified(10 ether);
+
+    // Malformed: declare 1 ether allocated, but leaf grants 10 ether. setPendingMerkleRoot only
+    // bounds against `totalNotified`, so this is acceptable to stage and promote.
+    _setLiveMerkleRoot(_singleLeafRoot(user, 10 ether), 1 ether);
+
+    bytes32[] memory empty = new bytes32[](0);
+    vm.expectRevert(bytes("exceeds allocated"));
+    distributor.claim(user, 10 ether, empty);
+  }
+
+  /// @dev Partial-overrun variant: first leaf fits within `totalAllocated`, second pushes total
+  ///      over the cap and must revert.
+  function test_claim_revertsExceedsAllocated_partial() public {
+    _injectNotified(10 ether);
+    (bytes32 root, bytes32[] memory p0, bytes32[] memory p1) = _twoLeafTree(user, 4 ether, other, 6 ether);
+    // Declared 5, leaves sum to 10. First 4-claim succeeds, second 6-claim trips the new cap.
+    _setLiveMerkleRoot(root, 5 ether);
+
+    distributor.claim(user, 4 ether, p0);
+    assertEq(distributor.totalClaimed(), 4 ether);
+
+    vm.expectRevert(bytes("exceeds allocated"));
+    distributor.claim(other, 6 ether, p1);
   }
 
   function test_claim_twoLeafTree() public {


### PR DESCRIPTION
## Summary

Addresses two findings from the Sherlock May 7th 2026 audit on `LisAsterDistributor`:
- **#6** — `_consume()` did not cap payouts at `totalAllocated`, so a malformed root could pay more than the declared budget.
- **#10** — `changeWaitingPeriod()` read the live value at accept time, allowing the admin to implicitly shrink MANAGER's veto window on an in-flight pending root.

Findings #7, #8, #9 were reviewed and intentionally not fixed (trust model accepts the MANAGER multisig; #8 is informational and offchain-bound).

## Change type

- [ ] New contract
- [ ] Upgrade (existing proxy)
- [x] Bug fix
- [ ] Gas optimization
- [ ] Configuration change
- [ ] Migration / deploy script
- [x] Test
- [ ] Dependency update

Note: `LisAsterDistributor` is UUPS-upgradeable, so deployment of this fix will be via `upgradeToAndCall`. No storage-layout changes (see below), so the upgrade is layout-safe.

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| `LisAsterDistributor` | `src/lisaster/LisAsterDistributor.sol` | modified |
| `LisAsterDistributorTest` | `test/lisAster/LisAsterDistributor.t.sol` | modified |

## Interface changes

No external/public signatures, events, or errors added or removed. Two behavior changes that surface as new revert strings:
- `_consume()` (called by `claim` / `claimAndStake`) now reverts `"exceeds allocated"` when a payout would push `totalClaimed` above `totalAllocated`.
- `changeWaitingPeriod()` now reverts `"pending root exists"` when called while `pendingMerkleRoot != 0`.

## Storage layout

Unchanged. `forge inspect LisAsterDistributor storage-layout` shows the same 13 slots (0–12) as before; this PR adds only `require` statements and a doc comment, no state variables. Layout-safe upgrade.

## Access control

Unchanged. `_consume` is still proof-gated and `changeWaitingPeriod` still `onlyRole(DEFAULT_ADMIN_ROLE)`. The new `changeWaitingPeriod` precondition is purely procedural — admin must wait for the pending root to clear (via `acceptMerkleRoot` or MANAGER `revokePendingMerkleRoot`).

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | No state variables added/reordered. |
| Fund safety | 🟢 None | Both changes are tighter `require`s; they can only revert, never widen what is allowed. The `totalClaimed <= totalAllocated` cap *reduces* worst-case loss under a compromised BOT scenario. |
| Access control | 🟢 None | No role changes. |
| External call safety | 🟢 None | No new external calls. |

## Deployment

BSC mainnet (and any other chain where `LisAsterDistributor` is deployed). Standard UUPS upgrade flow via the existing `DEFAULT_ADMIN_ROLE`. No new env vars; no initializer changes.

## Test plan

- [x] `forge test --match-path 'test/lisAster/*'` passes — 104/104 (was 99, +5 new regression tests).
- [x] New tests cover the `"exceeds allocated"` revert (single-leaf overrun + two-leaf partial overrun) and the `"pending root exists"` guard (revert while pending, allowed after accept, allowed after revoke).
- [ ] Pre-deploy: dry-run upgrade against the testnet proxy and re-run testnet integration scripts.
- [ ] Mainnet upgrade timelock review by MANAGER multisig.