### PR TITLE
chore(audit-agent): onboard cloud-auditor

### DIFF
--- a/.github/audit-config.yml
+++ b/.github/audit-config.yml
@@ -1,0 +1,22 @@
+audit_doc_paths:
+  - docs/audits/*.pdf
+
+actor_allowlist:
+  - lawson-ccy
+  - razww
+  - qingyang-lista
+  - ricklista
+
+escalation_reviewers:
+  - "@lista-dao/sc"
+
+telegram:
+  chat_id: -4110669414
+  send_pdf: true
+  caption_prefix: "[Lista-New-Contracts]"
+
+delivery:
+  also_post_to_slack: false
+
+focus_defaults:
+  skip: []


### PR DESCRIPTION
Onboard `lista-dao/lista-new-contracts` to the cloud-auditor multi-agent audit system (see `risk-ops/modules/cloud-auditor`).

This adds `.github/audit-config.yml` which controls:

- `actor_allowlist` — who can trigger `@audit-agent` on PRs
- `telegram.chat_id` / `caption_prefix` — where the full PDF report is delivered
- `audit_doc_paths` — where the ingest agent looks for merged audit PDFs to learn from
