### PR TITLE
fix(slisXAUE): CertiK preliminary audit fixes (LDS-05/09/11/12)

### DIFF
--- a/src/slisXAUE/XAUTStaking.sol
+++ b/src/slisXAUE/XAUTStaking.sol
@@ -65,7 +65,8 @@ contract XAUTStaking is
   uint256 public minDeposit;
   /// @notice Minimum withdraw request, in asset (XAUT, 6-dec) units
   uint256 public minWithdraw;
-  /// @notice Maximum total shares (18-dec). Risk control; users do not see this number.
+  /// @notice Maximum total slisXAUE shares (18-dec). Risk-control cap set by MANAGER; checked at deposit time.
+  ///         Publicly readable on-chain (auto getter + MintCapUpdated event).
   uint256 public mintCap;
 
   /* CONSTANTS */
@@ -169,6 +170,12 @@ contract XAUTStaking is
       shares = convertToShares(amount);
     } else {
       amount = convertToAssets(shares);
+      // Round the charged amount up so the depositor never pays less than the fair value of
+      // the minted shares (mirrors requestWithdraw's share round-up). The amount>0 guard keeps
+      // sub-wei share-input reverting at `require(amount > 0)` below, preserving audit finding C. (CertiK LDS-05)
+      if (amount > 0 && convertToShares(amount) < shares) {
+        amount += 1;
+      }
     }
 
     require(shares > 0, "shares is zero");
@@ -292,7 +299,9 @@ contract XAUTStaking is
       scaled = userTotalAssetsScaled; // cap
     }
     userTotalAssetsScaled -= scaled;
-    emit DecreaseTotalAssets(amount);
+    // Emit the executed (capped) amount so off-chain TVL/loss reconstruction does not over-subtract when the
+    // cap binds. `scaled` is always an exact multiple of SCALE_RATIO, so this division is loss-free. (CertiK LDS-11)
+    emit DecreaseTotalAssets(scaled / SCALE_RATIO);
   }
 
   /**
@@ -345,6 +354,38 @@ contract XAUTStaking is
   /// @notice Get the full withdrawal request list for `user`
   function getUserWithdrawalRequests(address user) external view returns (WithdrawalRequest[] memory) {
     return userWithdrawalRequests[user];
+  }
+
+  /// @notice Number of outstanding (unclaimed) withdrawal requests for `user`.
+  /// @dev Decreases as the user claims (swap-and-pop in claimWithdraw); not a lifetime counter.
+  function getUserWithdrawalRequestCount(address user) external view returns (uint256) {
+    return userWithdrawalRequests[user].length;
+  }
+
+  /// @notice Paginated slice of `user`'s withdrawal requests over the half-open range [start, end).
+  /// @dev `end` is clamped to the array length, so callers may pass a large `end` (e.g. type(uint256).max)
+  ///      to read to the end; returns an empty array when start >= length. Indices are unstable across
+  ///      claims (swap-and-pop moves the last element into the claimed slot), so clients should key on
+  ///      (batchId, amount) content rather than a stable index. (CertiK LDS-12)
+  /// @param start First index (inclusive)
+  /// @param end Exclusive upper bound; clamped to the current array length
+  function getUserWithdrawalRequests(
+    address user,
+    uint256 start,
+    uint256 end
+  ) external view returns (WithdrawalRequest[] memory page) {
+    WithdrawalRequest[] storage reqs = userWithdrawalRequests[user];
+    uint256 len = reqs.length;
+    if (end > len) {
+      end = len;
+    }
+    if (start >= end) {
+      return new WithdrawalRequest[](0);
+    }
+    page = new WithdrawalRequest[](end - start);
+    for (uint256 i = start; i < end; i++) {
+      page[i - start] = reqs[i];
+    }
   }
 
   /// @notice 18 decimals fixed (matches slisXAUE)

--- a/test/slisXAUE/SlisXAUE.t.sol
+++ b/test/slisXAUE/SlisXAUE.t.sol
@@ -38,6 +38,9 @@ contract SlisXAUETest is Test {
   uint256 constant FEE_RATE = 0.2e18; // 20%
   uint256 constant MIN_DEPOSIT = 1000;
 
+  // Redeclared for vm.expectEmit (mirrors XAUTStaking.DecreaseTotalAssets).
+  event DecreaseTotalAssets(uint256 amount);
+
   function setUp() public {
     // External XAUE Protocol mocks
     xaut = new MockXAUT();
@@ -104,6 +107,33 @@ contract SlisXAUETest is Test {
     vm.expectRevert(bytes("amount is zero"));
     staking.deposit(0, 1, alice); // amount=0, shares=1 → converted amount = 0 → revert
     vm.stopPrank();
+  }
+
+  function test_deposit_shares_input_rounds_charged_amount_up() public {
+    // LDS-05: when the user specifies `shares`, the charged XAUT must round UP so the depositor
+    // never pays less than the fair value of the minted shares (rounding favours the pool).
+    _deposit(alice, 100e6); // 100 XAUT -> 100e18 shares, userTotalAssetsScaled = 100e18
+
+    // Push 3 XAUT interest so the share price becomes inexact (uta=103e18, supply=100e18).
+    vm.prank(address(adapter));
+    staking.increaseTotalAssets(3e6);
+
+    uint256 wantShares = 1e18;
+    uint256 floored = staking.convertToAssets(wantShares); // what the un-rounded (floor) charge would be
+    // Precondition: at this rate the floored charge under-prices the shares, so the guard must fire.
+    assertLt(staking.convertToShares(floored), wantShares, "precondition: floored charge under-prices shares");
+
+    uint256 bobBefore = xaut.balanceOf(bob);
+    vm.startPrank(bob);
+    xaut.approve(address(staking), type(uint256).max);
+    staking.deposit(0, wantShares, bob);
+    vm.stopPrank();
+
+    uint256 charged = bobBefore - xaut.balanceOf(bob);
+    assertEq(charged, floored + 1, "charged amount must be rounded up by 1 wei");
+    assertEq(slisXAUE.balanceOf(bob), wantShares, "bob receives exactly the requested shares");
+    // Pool is protected: the rounded-up charge is now worth at least the minted shares.
+    assertGe(staking.convertToShares(charged), wantShares, "rounded-up charge covers the shares");
   }
 
   function test_requestWithdraw_zero_amount_via_shares_path_reverts() public {
@@ -538,6 +568,45 @@ contract SlisXAUETest is Test {
   function test_decreaseTotalAssets_only_adapter() public {
     vm.expectRevert(bytes("only adapter"));
     staking.decreaseTotalAssets(1e6);
+  }
+
+  function test_getUserWithdrawalRequests_pagination() public {
+    _deposit(alice, 100e6);
+    vm.startPrank(alice);
+    staking.requestWithdraw(10e6, 0, alice);
+    staking.requestWithdraw(20e6, 0, alice);
+    staking.requestWithdraw(30e6, 0, alice);
+    vm.stopPrank();
+
+    assertEq(staking.getUserWithdrawalRequestCount(alice), 3, "3 outstanding requests");
+    assertEq(staking.getUserWithdrawalRequests(alice).length, 3, "full getter returns all");
+
+    // Page [1, 3) -> indices 1 and 2.
+    XAUTStaking.WithdrawalRequest[] memory page = staking.getUserWithdrawalRequests(alice, 1, 3);
+    assertEq(page.length, 2, "page [1,3) has 2");
+    assertEq(page[0].amount, 20e6, "page[0] == request #1");
+    assertEq(page[1].amount, 30e6, "page[1] == request #2");
+
+    // end clamped beyond length.
+    XAUTStaking.WithdrawalRequest[] memory clamped = staking.getUserWithdrawalRequests(alice, 2, 999);
+    assertEq(clamped.length, 1, "clamped to length");
+    assertEq(clamped[0].amount, 30e6, "last entry");
+
+    // start >= end -> empty.
+    assertEq(staking.getUserWithdrawalRequests(alice, 3, 3).length, 0, "empty page");
+  }
+
+  function test_decreaseTotalAssets_emits_capped_amount() public {
+    _deposit(alice, 100e6); // userTotalAssetsScaled = 100e18
+
+    // Adapter pushes a loss larger than the tracked base: storage caps at userTotalAssetsScaled, and the
+    // event must report the executed (capped) amount, not the raw 200 XAUT input. (CertiK LDS-11)
+    vm.expectEmit(true, true, true, true, address(staking));
+    emit DecreaseTotalAssets(100e6);
+    vm.prank(address(adapter));
+    staking.decreaseTotalAssets(200e6);
+
+    assertEq(staking.totalAssets(), 0, "all tracked assets removed");
   }
 
   // ─── Pause behavior ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Addresses the four **code-level** findings from CertiK's slisXAUE preliminary audit (LDS-05, LDS-09, LDS-11, LDS-12). All are Minor / Informational / Optimization. The remaining 11 findings are centralization / by-design / discussion items resolved via governance or written responses (no code change) and are tracked separately.

## Changes — `src/slisXAUE/XAUTStaking.sol`
- **LDS-05 (Minor)** — `deposit()` shares-input branch now rounds the charged XAUT **up**, guarded on `amount > 0`, so a depositor never pays below the fair value of the minted shares. The guard preserves the existing sub-wei revert (`deposit(0, 1)` still reverts `"amount is zero"`, audit finding C). Restores the contract-wide "rounding always favours the pool" invariant (`requestWithdraw` already rounds shares up).
- **LDS-09 (Info)** — reworded `mintCap` NatSpec; dropped the misleading "users do not see this number" (the cap is publicly readable and is checked at deposit time).
- **LDS-11 (Info)** — `decreaseTotalAssets` now emits the executed (capped) amount `scaled / SCALE_RATIO` instead of the raw input, so off-chain TVL/loss reconstruction does not over-subtract when the cap binds. The division is loss-free (`userTotalAssetsScaled` is always a multiple of `SCALE_RATIO`). `increaseTotalAssets` and the `*Skipped` events are unchanged.
- **LDS-12 (Optimization)** — added `getUserWithdrawalRequestCount(address)` and a paginated `getUserWithdrawalRequests(address user, uint256 start, uint256 end)` (half-open `[start, end)`, `end` clamped to length, empty when `start >= end`). The full-array getter is retained for backward compatibility.

## Storage layout
**No change.** LDS-05/09/11 touch logic / comment / event-arg only; LDS-12 adds view functions only. UUPS-safe.

## Testing
`forge test --match-path 'test/slisXAUE/*'` → **52/52 green**. New tests:
- `test_deposit_shares_input_rounds_charged_amount_up`
- `test_decreaseTotalAssets_emits_capped_amount`
- `test_getUserWithdrawalRequests_pagination`

The finding-C regression test (`test_deposit_zero_amount_via_shares_path_reverts`) stays green.

## Out of scope (no code change this PR)
- **Governance:** LDS-01 / LDS-02 / LDS-03 — `DEFAULT_ADMIN_ROLE` → TimeLock (24h) + Gnosis Safe; `emergencyWithdraw` kept on MANAGER multisig.
- **By-design / discussion:** LDS-04 (NAV circuit breaker), LDS-06 (`totalSupply==0` funding gap, Lista DAO backstops the final-withdrawal loss), LDS-07 (`minRedeemShares`), LDS-08 (slippage), LDS-10 (non-FoT asset), LDS-13 (no HWM), LDS-14 (async delays), LDS-15 (burn-at-request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)