### PR TITLE
fix(slisXAUE): Bailsec 1st-report audit fixes

### DIFF
--- a/src/slisXAUE/XAUEAdapter.sol
+++ b/src/slisXAUE/XAUEAdapter.sol
@@ -53,7 +53,7 @@ contract XAUEAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable, Ree
   /// @notice XAUTStaking — receives interest & withdrawal funds
   address public staking;
   /// @notice slisXAUE share token. Cached at initialize to avoid an extra cross-contract hop on
-  ///         every NAV sync (`_pushInterest` / `_pushLoss` need `totalSupply` for the no-holders
+  ///         every NAV sync (`_pushInterest` needs `totalSupply` for the no-holders
   ///         protocol-surplus branch).
   address public slisXAUE;
   /// @notice Fee recipient (XAUT)
@@ -103,7 +103,6 @@ contract XAUEAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable, Ree
   event RequestRedeemFromVault(uint256 indexed reqId, uint256 assetAmount, uint256 shareAmount);
   event ClaimFee(address feeReceiver, uint256 feeAmount);
   event UpdateVaultAssets(uint256 newTotal, uint256 totalInterest, uint256 interestFee, uint256 netInterest);
-  event VaultLoss(uint256 newTotal, uint256 totalLoss);
   event SetFeeReceiver(address feeReceiver);
   event SetFeeRate(uint256 feeRate);
   event SetStaking(address staking);
@@ -180,6 +179,9 @@ contract XAUEAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable, Ree
    */
   function depositToVault(uint256 assetAmount) external onlyRole(BOT) nonReentrant {
     require(assetAmount > 0, "amount is zero");
+    // Surface XAUE's own deposit floor at the adapter boundary instead of reverting deep inside
+    // mint(), mirroring the min-redeem pre-check in requestWithdrawFromVault. (Bailsec 25)
+    require(assetAmount >= IXAUEFundToken(xaueFundToken).minDepositAmount(), "below xaue minDeposit");
 
     _updateVaultAssets();
 
@@ -282,6 +284,9 @@ contract XAUEAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable, Ree
 
   function setFeeRate(uint256 _feeRate) external onlyRole(MANAGER) {
     require(_feeRate <= MAX_FEE_RATE, "fee rate too high");
+    // Settle accrued NAV at the OLD rate before switching, so the new rate only applies to gains that
+    // accrue afterward (no hindsight re-taxing of the pending delta). (Bailsec 15)
+    _updateVaultAssets();
     feeRate = _feeRate;
     emit SetFeeRate(_feeRate);
   }
@@ -289,9 +294,31 @@ contract XAUEAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable, Ree
   function setMaxDeltaBps(uint256 _maxDeltaBps) external onlyRole(MANAGER) {
     require(_maxDeltaBps > 0, "maxDeltaBps is zero");
     require(_maxDeltaBps <= MAX_DELTA_BPS_CAP, "maxDeltaBps too high");
+    // When LOWERING the cap, settle the accrued delta under the current (higher) cap first, so a
+    // pending in-cap move books before the tighter cap takes effect and can't freeze the next
+    // sync-first flow. When RAISING, do NOT sync first: that path exists precisely to clear a backlog
+    // whose delta exceeds the current cap, and a pre-sync would revert and block the raise. (Bailsec 18)
+    if (_maxDeltaBps < maxDeltaBps) {
+      _updateVaultAssets();
+    }
     uint256 old = maxDeltaBps;
     maxDeltaBps = _maxDeltaBps;
     emit SetMaxDeltaBps(old, _maxDeltaBps);
+  }
+
+  /**
+   * @notice Repoint the XAUE oracle (e.g. when XAUE migrates the oracle its FundToken uses). Settles
+   *         accrued NAV under the OLD oracle, switches, then re-baselines `lastVaultTotalAssets`
+   *         against the NEW oracle so the change of pricing BASIS is not mis-booked as interest/loss.
+   *         A real cross-oracle discrepancy is an anomaly for MANAGER to reconcile, not yield. Has
+   *         broad side-effects; use only to mirror an XAUE oracle migration. (Bailsec 16)
+   */
+  function setXAUEOracle(address _xaueOracle) external onlyRole(MANAGER) {
+    require(_xaueOracle != address(0), "xaueOracle is zero");
+    _updateVaultAssets();
+    xaueOracle = _xaueOracle;
+    lastVaultTotalAssets = getVaultTotalAssets();
+    emit SetXAUEOracle(_xaueOracle);
   }
 
   /**
@@ -372,8 +399,10 @@ contract XAUEAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable, Ree
   /**
    * @dev Reconcile XAUE NAV movement against staking-side accounting.
    *      - NAV up (profit): charge feeRate% to `fee`, push remainder to staking as interest.
-   *      - NAV down (loss): push the full loss to staking; users bear it pro-rata via convertRate.
-   *        Fee is NOT clawed back (already credited on past upside).
+   *      - NAV down: impossible by construction -- CoboFundOracle NAV is monotonically non-decreasing
+   *        (APR >= 0; every updateRate ratchets baseNetValue up via getLatestPrice). A decrease
+   *        signals an oracle anomaly, not a real loss, so the sync fails closed instead of
+   *        socialising a phantom loss onto holders. (Bailsec 03/04/06/28/29 -- loss path removed.)
    *
    *      Per-update absolute delta is capped at `maxDeltaBps` of `lastVaultTotalAssets` (default 10%,
    *      MANAGER-tunable up to MAX_DELTA_BPS_CAP). Defends against oracle anomalies; if exceeded,
@@ -388,21 +417,22 @@ contract XAUEAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable, Ree
     require(IERC20(xaueFundToken).balanceOf(address(this)) >= expectedShareBalance, "share balance below expected");
 
     uint256 newVaultTotalAssets = getVaultTotalAssets();
+    // XAUE NAV cannot decrease (see @dev). A drop is an oracle anomaly -- fail closed rather than
+    // propagate a loss the product cannot incur.
+    require(newVaultTotalAssets >= lastVaultTotalAssets, "vault value decreased");
+
     if (newVaultTotalAssets > lastVaultTotalAssets) {
       uint256 totalInterest = newVaultTotalAssets - lastVaultTotalAssets;
       (uint256 interestFee, uint256 netInterest) = _pushInterest(totalInterest, lastVaultTotalAssets);
       emit UpdateVaultAssets(newVaultTotalAssets, totalInterest, interestFee, netInterest);
-    } else if (newVaultTotalAssets < lastVaultTotalAssets) {
-      uint256 totalLoss = lastVaultTotalAssets - newVaultTotalAssets;
-      _pushLoss(totalLoss, lastVaultTotalAssets);
-      emit VaultLoss(newVaultTotalAssets, totalLoss);
     }
     lastVaultTotalAssets = newVaultTotalAssets;
   }
 
   /**
    * @dev Charge feeRate% on `gain` to `fee`, push net to staking via increaseTotalAssets. Reverts
-   *      if `gain / baseValue > maxDeltaBps / 10000` (oracle anomaly guard).
+   *      if `gain / baseValue > maxDeltaBps / 10000` (oracle anomaly guard), except when
+   *      `baseValue == 0`, where the ratio cap is undefined and is skipped (see inline note).
    *
    *      Special-case when there are no slisXAUE holders (`totalSupply == 0`): the entire `gain` is
    *      attributed to `fee`. Protocol is the only stakeholder during such windows, so no user
@@ -413,7 +443,14 @@ contract XAUEAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable, Ree
    *      the next sync rather than pushing here directly.
    */
   function _pushInterest(uint256 gain, uint256 baseValue) private returns (uint256 gainFee, uint256 netGain) {
-    require(gain * 10000 <= baseValue * maxDeltaBps, "delta exceeds max");
+    // baseValue == 0 means the prior tracked value floored to 0 while expectedShareBalance is still a
+    // sub-1-XAUT dust residual (after a full fee-redemption or a near-full staker exit). The per-update
+    // ratio cap is undefined against a zero base and would make the next 0 -> positive transition revert
+    // forever, bricking every sync-first entry point. Skip it in that degenerate case -- the gain is
+    // dust-bounded, not an oracle anomaly. (Bailsec 05/10)
+    if (baseValue > 0) {
+      require(gain * 10000 <= baseValue * maxDeltaBps, "delta exceeds max");
+    }
 
     if (IERC20(slisXAUE).totalSupply() == 0) {
       fee += gain;
@@ -426,29 +463,6 @@ contract XAUEAdapter is AccessControlEnumerableUpgradeable, UUPSUpgradeable, Ree
     if (netGain > 0) {
       IXAUTStaking(staking).increaseTotalAssets(netGain);
     }
-  }
-
-  /**
-   * @dev Push the full `loss` to staking via decreaseTotalAssets. Reverts on cap breach. Fee is NOT
-   *      clawed back (already credited on past upside).
-   *
-   *      Special-case when there are no slisXAUE holders (`totalSupply == 0`): symmetric with the
-   *      gain path — `fee` absorbs the loss up to its current balance. Any residual is silently
-   *      absorbed by adapter's principal (the orphan share value lastVault drop already reflects).
-   *
-   *      Called only by `_updateVaultAssets`. `acknowledgeReject` defers any in-flight loss to
-   *      the next sync rather than pushing here directly.
-   */
-  function _pushLoss(uint256 loss, uint256 baseValue) private {
-    require(loss * 10000 <= baseValue * maxDeltaBps, "delta exceeds max");
-
-    if (IERC20(slisXAUE).totalSupply() == 0) {
-      uint256 absorbed = loss > fee ? fee : loss;
-      fee -= absorbed;
-      return;
-    }
-
-    IXAUTStaking(staking).decreaseTotalAssets(loss);
   }
 
   function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}

--- a/src/slisXAUE/XAUTStaking.sol
+++ b/src/slisXAUE/XAUTStaking.sol
@@ -86,11 +86,9 @@ contract XAUTStaking is
   event FinishWithdraw(uint256 indexed batchId, uint256 amount);
   event ClaimWithdrawal(address indexed user, uint256 idx, uint256 amount);
   event IncreaseTotalAssets(uint256 amount);
-  event DecreaseTotalAssets(uint256 amount);
-  /// @notice Emitted when adapter pushed interest/loss while no slisXAUE holders existed. Value stays
+  /// @notice Emitted when adapter pushed interest while no slisXAUE holders existed. Value stays
   ///         as adapter-side principal buffer; off-chain monitor should pick this up for reconciliation.
   event IncreaseTotalAssetsSkipped(uint256 amount);
-  event DecreaseTotalAssetsSkipped(uint256 amount);
   event MintCapUpdated(uint256 oldCap, uint256 newCap);
   event SetMinDeposit(uint256 minDeposit);
   event SetMinWithdraw(uint256 minWithdraw);
@@ -193,6 +191,10 @@ contract XAUTStaking is
   /**
    * @notice Burn slisXAUE immediately and queue a withdrawal request for XAUT. shares are burned at
    *         this call (Option A: "burn at request"). Cannot be cancelled.
+   * @dev    amount-input is exact: the most an amount-input request can ask for is convertToAssets(balance);
+   *         requesting more reverts ("insufficient shares"). For a guaranteed full exit use the shares-input
+   *         form requestWithdraw(0, balanceOf(user), receiver), which burns exactly the balance and is not
+   *         subject to that rounding boundary. (Bailsec 14)
    * @param amount XAUT amount (6-dec); pass 0 to specify shares instead
    * @param shares Share amount (18-dec); pass 0 to specify amount instead
    * @param receiver The address recorded as the request owner (target of future claim)
@@ -281,30 +283,6 @@ contract XAUTStaking is
   }
 
   /**
-   * @notice Push a NAV-drop loss from Adapter; reduces convertRate pro-rata (users bear the loss).
-   *         Caps at current `userTotalAssetsScaled` to avoid underflow; any leftover is silently
-   *         dropped — at that point adapter is over-reporting loss vs what users still own, which is
-   *         only possible if all active stake has been withdrawn.
-   * @dev    Also no-ops when `slisXAUE.totalSupply() == 0` (no holders to absorb the loss). Mirror
-   *         of the increaseTotalAssets guard.
-   */
-  function decreaseTotalAssets(uint256 amount) external {
-    require(msg.sender == adapter, "only adapter");
-    if (slisXAUE.totalSupply() == 0) {
-      emit DecreaseTotalAssetsSkipped(amount);
-      return;
-    }
-    uint256 scaled = amount * SCALE_RATIO;
-    if (scaled >= userTotalAssetsScaled) {
-      scaled = userTotalAssetsScaled; // cap
-    }
-    userTotalAssetsScaled -= scaled;
-    // Emit the executed (capped) amount so off-chain TVL/loss reconstruction does not over-subtract when the
-    // cap binds. `scaled` is always an exact multiple of SCALE_RATIO, so this division is loss-free. (CertiK LDS-11)
-    emit DecreaseTotalAssets(scaled / SCALE_RATIO);
-  }
-
-  /**
    * @notice Adapter delivers XAUT back to cover finalized withdrawal batches (FIFO). amount=0 is allowed
    *         (BOT can tick batch state without transferring new funds).
    */
@@ -347,6 +325,12 @@ contract XAUTStaking is
   }
 
   /// @notice 1 slisXAUE (1e18 wei) is worth pricePerShare() XAUT wei (6-dec). Convenience view.
+  /// @dev Last-synced snapshot: reads stored userTotalAssetsScaled WITHOUT syncing adapter NAV, so
+  ///      between BOT heartbeats it lags the true value by the unbooked NAV growth (bounded by the
+  ///      gold-backed oracle, ~0.0137%/day x time-since-sync). On-chain execution is unaffected --
+  ///      deposit/requestWithdraw sync via adapter.updateVaultAssets() before pricing. Off-chain
+  ///      consumers wanting the live value should eth_call adapter.updateVaultAssets() first, or
+  ///      derive it from adapter.getVaultTotalAssets() (live oracle NAV). (Bailsec 35)
   function pricePerShare() external view returns (uint256) {
     return convertToAssets(1e18);
   }

--- a/src/slisXAUE/interface/IXAUTStaking.sol
+++ b/src/slisXAUE/interface/IXAUTStaking.sol
@@ -5,9 +5,6 @@ interface IXAUTStaking {
   /// @notice Adapter pushes net interest to update share rate. Convert rate jumps immediately (no vesting).
   function increaseTotalAssets(uint256 amount) external;
 
-  /// @notice Adapter pushes a NAV-drop loss; reduces share rate pro-rata. Users bear the loss.
-  function decreaseTotalAssets(uint256 amount) external;
-
   /// @notice Adapter delivers XAUT back to staking to cover pending withdrawal batches (FIFO).
   function finishWithdraw(uint256 amount) external;
 

--- a/test/slisXAUE/SlisXAUE.t.sol
+++ b/test/slisXAUE/SlisXAUE.t.sol
@@ -38,9 +38,6 @@ contract SlisXAUETest is Test {
   uint256 constant FEE_RATE = 0.2e18; // 20%
   uint256 constant MIN_DEPOSIT = 1000;
 
-  // Redeclared for vm.expectEmit (mirrors XAUTStaking.DecreaseTotalAssets).
-  event DecreaseTotalAssets(uint256 amount);
-
   function setUp() public {
     // External XAUE Protocol mocks
     xaut = new MockXAUT();
@@ -354,6 +351,15 @@ contract SlisXAUETest is Test {
     adapter.requestWithdrawFromVault(0);
   }
 
+  function test_depositToVault_below_xaue_minDeposit_reverts() public {
+    // Mirror of the min-redeem pre-check: a sub-floor assetAmount must revert at the adapter
+    // boundary with a local message, not deep inside XAUE.mint(). (Bailsec 25)
+    uint256 floor = fundToken.minDepositAmount();
+    vm.prank(bot);
+    vm.expectRevert(bytes("below xaue minDeposit"));
+    adapter.depositToVault(floor - 1);
+  }
+
   function test_adapter_requestWithdrawFromVault_below_xaue_minRedeem_reverts() public {
     _deposit(alice, 100e6);
     vm.prank(bot);
@@ -462,67 +468,143 @@ contract SlisXAUETest is Test {
     assertGt(adapter.fee(), 0, "sync ran; fee accrued");
   }
 
-  // ─── NAV decline: users bear the loss pro-rata ────────────────────────────
+  // ─── NAV decline impossible: loss path removed (Bailsec 03/04/28) ────────────────────────────
 
-  function test_nav_decline_propagates_loss_to_users() public {
+  function test_nav_decline_reverts_fail_closed() public {
     _deposit(alice, 100e6);
     vm.prank(bot);
     adapter.depositToVault(100e6);
 
-    uint256 rateBefore = staking.pricePerShare();
-
-    // NAV drops 5% → adapter's XAUE worth ~95 XAUT instead of 100
+    // XAUE NAV cannot decrease in production (CoboFundOracle ratchets up). A drop is treated as an
+    // oracle anomaly: the sync fails closed instead of socialising a phantom loss. (Bailsec 03/04/28)
     oracle.setPrice((INITIAL_NAV * 95) / 100);
 
     vm.prank(bot);
+    vm.expectRevert(bytes("vault value decreased"));
     adapter.updateVaultAssets();
-
-    // No fee charged on loss (fee only on upside)
-    assertEq(adapter.fee(), 0, "no fee on loss");
-
-    // Rate dropped pro-rata
-    uint256 rateAfter = staking.pricePerShare();
-    assertLt(rateAfter, rateBefore, "rate decreased");
-
-    // Alice's stake is now worth ~95 XAUT
-    uint256 aliceValue = staking.convertToAssets(slisXAUE.balanceOf(alice));
-    assertApproxEqAbs(aliceValue, 95e6, 1, "alice's stake worth ~95 XAUT after 5% NAV drop");
   }
 
-  function test_nav_drop_then_recovery_users_bear_round_trip() public {
+  function test_nav_decline_reverts_even_after_gain() public {
     _deposit(alice, 100e6);
     vm.prank(bot);
     adapter.depositToVault(100e6);
 
-    // Up 10% → profit, fee charged
+    // Up 10% -> profit booked
     oracle.setPrice((INITIAL_NAV * 110) / 100);
     vm.prank(bot);
     adapter.updateVaultAssets();
-    uint256 feeAfterGain = adapter.fee();
-    assertEq(feeAfterGain, 2e6, "fee = 20% of 10 XAUT gain");
+    assertEq(adapter.fee(), 2e6, "fee = 20% of 10 XAUT gain");
 
-    // Back down 10% → loss propagated to users; fee NOT clawed back
+    // Any subsequent decline (even back toward the entry NAV) fails closed -- fee is never clawed
+    // back and no loss is propagated, because the product cannot incur a NAV loss.
     oracle.setPrice(INITIAL_NAV);
     vm.prank(bot);
+    vm.expectRevert(bytes("vault value decreased"));
     adapter.updateVaultAssets();
-    assertEq(adapter.fee(), feeAfterGain, "fee unchanged on loss");
-
-    // Net effect: alice deposited 100, gained 8 (80% of 10), then lost 10 → 98 XAUT
-    uint256 aliceValue = staking.convertToAssets(slisXAUE.balanceOf(alice));
-    assertApproxEqAbs(aliceValue, 98e6, 1, "alice ends at ~98 XAUT (gain kept fee, loss fully borne)");
   }
 
-  function test_nav_decline_above_max_delta_reverts() public {
+  function test_nav_decline_blocks_deposit_sync_fail_closed() public {
     _deposit(alice, 100e6);
     vm.prank(bot);
     adapter.depositToVault(100e6);
 
-    // 11% NAV drop exceeds the 10% delta cap → revert (defends against oracle anomaly)
-    oracle.setPrice((INITIAL_NAV * 89) / 100);
+    // A decline freezes user flows too, since deposit/requestWithdraw sync NAV first.
+    oracle.setPrice((INITIAL_NAV * 95) / 100);
 
+    address bob = makeAddr("bobDecline");
+    xaut.mint(bob, 10e6);
+    vm.startPrank(bob);
+    xaut.approve(address(staking), 10e6);
+    vm.expectRevert(bytes("vault value decreased"));
+    staking.deposit(10e6, 0, bob);
+    vm.stopPrank();
+  }
+
+  function test_setFeeRate_settles_pending_gain_at_old_rate() public {
+    // Bailsec 15: changing feeRate must not retroactively tax the un-synced gain. setFeeRate syncs
+    // at the OLD rate first, so the pending gain books at 20% and only future gain uses the new rate.
+    _deposit(alice, 100e6);
     vm.prank(bot);
+    adapter.depositToVault(100e6);
+
+    oracle.setPrice((INITIAL_NAV * 105) / 100); // +5% NAV, left UN-synced
+    assertEq(adapter.fee(), 0, "no fee booked yet");
+
+    vm.prank(manager);
+    adapter.setFeeRate(0.3e18); // 20% -> 30%
+
+    assertEq(adapter.fee(), 1e6, "pending 5 XAUT gain taxed at OLD 20% (no hindsight)");
+    assertEq(adapter.feeRate(), 0.3e18, "new rate set");
+    assertEq(adapter.lastVaultTotalAssets(), 105e6, "synced before switch");
+  }
+
+  function test_setMaxDeltaBps_lowering_settles_first_no_freeze() public {
+    // Bailsec 18: lowering the cap below an un-synced in-cap delta must not freeze the next sync.
+    _deposit(alice, 100e6);
+    vm.prank(bot);
+    adapter.depositToVault(100e6);
+
+    oracle.setPrice((INITIAL_NAV * 105) / 100); // +5% (within old 10% cap), un-synced
+
+    vm.prank(manager);
+    adapter.setMaxDeltaBps(100); // 10% -> 1%; settles the 5% under the old cap first
+    assertEq(adapter.maxDeltaBps(), 100, "cap lowered");
+    assertEq(adapter.lastVaultTotalAssets(), 105e6, "pending delta settled under old cap");
+
+    adapter.updateVaultAssets(); // NAV unchanged -> no delta -> must NOT revert
+    assertEq(adapter.lastVaultTotalAssets(), 105e6, "no freeze");
+  }
+
+  function test_setMaxDeltaBps_raising_does_not_settle_first_clears_backlog() public {
+    // Bailsec 18 / decision A: RAISING must NOT sync first, so MANAGER can raise the cap to clear a
+    // backlog whose delta exceeds the current cap (the 08/12 operational lever).
+    _deposit(alice, 100e6);
+    vm.prank(bot);
+    adapter.depositToVault(100e6);
+
+    vm.prank(manager);
+    adapter.setMaxDeltaBps(100); // tighten to 1% (NAV unchanged: settle is a no-op)
+
+    oracle.setPrice((INITIAL_NAV * 102) / 100); // +2% > 1% cap -> backlog
     vm.expectRevert(bytes("delta exceeds max"));
     adapter.updateVaultAssets();
+
+    vm.prank(manager);
+    adapter.setMaxDeltaBps(1000); // raise to 10% WITHOUT a pre-sync (else it would deadlock)
+    assertEq(adapter.maxDeltaBps(), 1000, "cap raised despite pending backlog");
+
+    adapter.updateVaultAssets(); // now clears under the new cap
+    assertEq(adapter.lastVaultTotalAssets(), 102e6, "backlog cleared");
+  }
+
+  function test_setXAUEOracle_rebaselines_no_misbooked_interest() public {
+    // Bailsec 16: MANAGER can repoint the adapter's oracle (e.g. XAUE migrates its oracle). The swap
+    // settles under the old oracle, then re-baselines against the new one, so a different pricing
+    // basis is absorbed (not mis-booked as interest/loss); real post-swap gains still book normally.
+    _deposit(alice, 100e6);
+    vm.prank(bot);
+    adapter.depositToVault(100e6);
+    uint256 feeBefore = adapter.fee();
+
+    // New oracle reads a different NAV basis for the SAME shares.
+    MockXAUEOracle newOracle = new MockXAUEOracle((INITIAL_NAV * 150) / 100);
+    vm.prank(manager);
+    adapter.setXAUEOracle(address(newOracle));
+
+    assertEq(adapter.xaueOracle(), address(newOracle), "oracle repointed");
+    assertEq(adapter.fee(), feeBefore, "cross-oracle basis NOT booked as interest/fee");
+    assertEq(adapter.lastVaultTotalAssets(), adapter.getVaultTotalAssets(), "re-baselined to new oracle");
+    assertEq(adapter.lastVaultTotalAssets(), 150e6, "= expectedShareBalance * newNav");
+
+    // A real gain under the NEW oracle books normally.
+    newOracle.setPrice((INITIAL_NAV * 153) / 100); // 150 -> 153 (+2% on the new basis)
+    adapter.updateVaultAssets();
+    assertGt(adapter.fee(), feeBefore, "real gain under new oracle books as interest");
+
+    // Only MANAGER can repoint.
+    vm.prank(bot);
+    vm.expectRevert();
+    adapter.setXAUEOracle(address(oracle));
   }
 
   function test_nav_growth_above_max_delta_reverts() public {
@@ -551,23 +633,17 @@ contract SlisXAUETest is Test {
     assertGt(adapter.fee(), 0, "fee accrued at exactly 10% growth");
   }
 
-  function test_nav_decline_exactly_at_cap_succeeds() public {
+  function test_nav_growth_exactly_at_cap_decline_path_removed() public {
+    // The matching "decline exactly at cap succeeds" case is gone: declines now always revert
+    // (loss path removed). The only at-cap behaviour that remains is the upside, covered above.
     _deposit(alice, 100e6);
     vm.prank(bot);
     adapter.depositToVault(100e6);
 
-    // 10% drop — exactly at cap, should pass
-    oracle.setPrice((INITIAL_NAV * 90) / 100);
+    oracle.setPrice((INITIAL_NAV * 90) / 100); // -10%, in cap, but loss path is gone
     vm.prank(bot);
+    vm.expectRevert(bytes("vault value decreased"));
     adapter.updateVaultAssets();
-
-    uint256 aliceValue = staking.convertToAssets(slisXAUE.balanceOf(alice));
-    assertApproxEqAbs(aliceValue, 90e6, 1, "alice loses ~10% at exactly cap drop");
-  }
-
-  function test_decreaseTotalAssets_only_adapter() public {
-    vm.expectRevert(bytes("only adapter"));
-    staking.decreaseTotalAssets(1e6);
   }
 
   function test_getUserWithdrawalRequests_pagination() public {
@@ -594,19 +670,6 @@ contract SlisXAUETest is Test {
 
     // start >= end -> empty.
     assertEq(staking.getUserWithdrawalRequests(alice, 3, 3).length, 0, "empty page");
-  }
-
-  function test_decreaseTotalAssets_emits_capped_amount() public {
-    _deposit(alice, 100e6); // userTotalAssetsScaled = 100e18
-
-    // Adapter pushes a loss larger than the tracked base: storage caps at userTotalAssetsScaled, and the
-    // event must report the executed (capped) amount, not the raw 200 XAUT input. (CertiK LDS-11)
-    vm.expectEmit(true, true, true, true, address(staking));
-    emit DecreaseTotalAssets(100e6);
-    vm.prank(address(adapter));
-    staking.decreaseTotalAssets(200e6);
-
-    assertEq(staking.totalAssets(), 0, "all tracked assets removed");
   }
 
   // ─── Pause behavior ───────────────────────────────────────────────────────
@@ -823,7 +886,7 @@ contract SlisXAUETest is Test {
     assertEq(adapter.lastVaultTotalAssets(), expectedLast, "last reflects all 100 shares at navAtAck");
   }
 
-  function test_acknowledgeReject_defers_combined_loss_to_next_sync() public {
+  function test_acknowledgeReject_then_decline_sync_reverts() public {
     _deposit(alice, 100e6);
     vm.prank(bot);
     adapter.depositToVault(100e6);
@@ -831,20 +894,18 @@ contract SlisXAUETest is Test {
     (uint256 reqId, uint256 burntShareAmount, uint256 assetAmount) = _initiateRedemption(30e6);
     fundToken.rejectRedemption(reqId, address(adapter), assetAmount, burntShareAmount);
 
+    // NAV ends below the request-time value the ack re-credits -> the next sync sees a net decline.
+    // ack itself still pushes nothing; the sync then fails closed (loss path removed).
     uint256 navAtAck = (INITIAL_NAV * 95) / 100;
     oracle.setPrice(navAtAck);
 
     uint256 stakingBefore = staking.userTotalAssetsScaled();
     vm.prank(bot);
     adapter.acknowledgeReject(reqId);
-    assertEq(staking.userTotalAssetsScaled(), stakingBefore, "ack pushes no loss");
+    assertEq(staking.userTotalAssetsScaled(), stakingBefore, "ack pushes nothing");
 
+    vm.expectRevert(bytes("vault value decreased"));
     adapter.updateVaultAssets();
-    uint256 totalLoss = ((70e6 + 30e6) * 5) / 100; // 5e6
-    assertEq(stakingBefore - staking.userTotalAssetsScaled(), totalLoss * 1e12, "combined loss on next sync");
-
-    uint256 expectedLast = (adapter.expectedShareBalance() * navAtAck) / 1e30;
-    assertEq(adapter.lastVaultTotalAssets(), expectedLast);
   }
 
   function test_acknowledgeReject_only_bot() public {
@@ -945,31 +1006,69 @@ contract SlisXAUETest is Test {
     assertEq(slisXAUE.balanceOf(newUser), 100e18, "next user gets 100 slisXAUE 1:1");
   }
 
-  function test_limbo_loss_absorbed_by_fee_up_to_balance() public {
+  function test_limbo_decline_reverts_fail_closed() public {
     _deposit(alice, 100e6);
     vm.prank(bot);
     adapter.depositToVault(100e6);
 
-    // Alice exits at the original NAV (clean rounding) → limbo state
+    // Alice exits at the original NAV (clean rounding) -> limbo state (totalSupply == 0)
     vm.prank(alice);
     staking.requestWithdraw(100e6, 0, alice);
     assertEq(slisXAUE.totalSupply(), 0);
     assertEq(adapter.fee(), 0);
 
-    // NAV +5% during limbo → entire gain routed to fee
+    // NAV +5% during limbo -> entire gain routed to fee (gain path still works)
     oracle.setPrice((INITIAL_NAV * 105) / 100);
     adapter.updateVaultAssets();
-    uint256 feeAfterGain = adapter.fee();
-    assertGt(feeAfterGain, 0, "fee accumulated during limbo gain");
+    assertGt(adapter.fee(), 0, "fee accumulated during limbo gain");
 
-    // NAV -2% (still in limbo) → loss absorbed from fee
+    // A subsequent decline (even in limbo) fails closed -- with the loss path removed `fee` no
+    // longer acts as a loss buffer. (Bailsec 06 -- claimFee-bypass precondition eliminated.)
     uint256 navAtLoss = (oracle.getLatestPrice() * 98) / 100;
     oracle.setPrice(navAtLoss);
-    uint256 utaBefore = staking.userTotalAssetsScaled();
+    vm.expectRevert(bytes("vault value decreased"));
     adapter.updateVaultAssets();
+  }
 
-    assertLt(adapter.fee(), feeAfterGain, "fee absorbed limbo loss");
-    assertEq(staking.userTotalAssetsScaled(), utaBefore, "uta unchanged during limbo loss");
+  function test_zero_base_gain_does_not_brick_after_dust_residual() public {
+    // Bailsec 05/10: reach the broken state expectedShareBalance > 0 with lastVaultTotalAssets == 0
+    // (a sub-1-XAUT dust residual left after a full redemption), then prove the next NAV increase
+    // syncs instead of reverting "delta exceeds max". Loss-path removal does NOT fix this; the
+    // baseValue == 0 guard in _pushInterest does. Before the fix updateVaultAssets() reverted here.
+
+    // Non-round NAV so the getVaultTotalAssets floor vs requestWithdrawFromVault ceil leave a residual.
+    uint256 nav0 = 1e15 + 7;
+    oracle.setPrice(nav0);
+
+    _deposit(alice, 100e6);
+    vm.prank(bot);
+    adapter.depositToVault(100e6);
+
+    // Alice fully exits -> totalSupply == 0 (the fee-only regime in the finding).
+    vm.prank(alice);
+    staking.requestWithdraw(100e6, 0, alice);
+    assertEq(slisXAUE.totalSupply(), 0);
+
+    // BOT redeems the full rounded vault value; ceil-vs-floor leaves a dust residual whose XAUT
+    // value floors to 0 -> lastVaultTotalAssets becomes 0 while expectedShareBalance is still > 0.
+    uint256 fullValue = adapter.getVaultTotalAssets();
+    vm.prank(bot);
+    adapter.requestWithdrawFromVault(fullValue);
+
+    uint256 residual = adapter.expectedShareBalance();
+    assertGt(residual, 0, "precondition: dust residual remains");
+    assertEq(adapter.lastVaultTotalAssets(), 0, "precondition: lastVault floored to 0");
+
+    // NAV rises enough that the residual is worth >= 1 XAUT raw unit again (0 -> positive base).
+    uint256 navUp = (1e30 / residual) + 1;
+    oracle.setPrice(navUp);
+    assertGt(adapter.getVaultTotalAssets(), 0, "residual now worth >= 1");
+
+    // Must NOT revert (cap skipped against the zero base); the dust gain is routed to fee.
+    uint256 feeBefore = adapter.fee();
+    adapter.updateVaultAssets();
+    assertGt(adapter.lastVaultTotalAssets(), 0, "base re-established after sync");
+    assertGt(adapter.fee(), feeBefore, "dust gain routed to fee (totalSupply == 0)");
   }
 
   function test_dust_attack_tolerated_and_sweepable() public {


### PR DESCRIPTION
## Summary

Fixes for the **Bailsec — SlisXAUE 1st Report** (audited commit `3dd605e`), on top of the CertiK preliminary fixes (PR #32, `b2de6c8`).

Dominant change: **the NAV loss path is removed.** The XAUE `CoboFundOracle` is monotonically non-decreasing (verified on-chain — NAV = base·(1+APR·t), APR ≥ 0, `baseNetValue` only ratchets up via `updateRate`, no setter lowers it). `_updateVaultAssets` now fail-closes on a NAV decrease (`"vault value decreased"`) and the loss machinery is deleted.

## Changes

- **Loss path removed** — `require(newVault >= lastVault)` in `_updateVaultAssets`; deleted `XAUEAdapter._pushLoss`, `VaultLoss`, `XAUTStaking.decreaseTotalAssets` (+ events + `IXAUTStaking` entry). Resolves Bailsec **03/04/06/28/29** (26 moot).
- **`_pushInterest`** skips the ratio cap when `baseValue == 0` — fixes the zero-base gain DoS from a dust residual / near-full exit (**05/10**).
- **`setFeeRate`** settles accrued NAV at the old rate before switching (**15**).
- **`setMaxDeltaBps`** settles first only when *lowering* the cap, preserving the raise-to-clear-backlog lever (**18**).
- **`setXAUEOracle`** (new MANAGER fn): settle → switch → re-baseline, so an oracle-basis change isn't mis-booked as interest/loss (**16**).
- **`depositToVault`** pre-checks XAUE `minDepositAmount` (**25**).
- **NatSpec** — shares-input is the guaranteed max-exit (**14**); `pricePerShare` is a last-synced snapshot (**35**).

## Storage layout

**Unchanged** — only functions, events, and one interface entry were removed/added; no storage variables touched. Safe for UUPS upgrade.

## Dispositions

**10 Fixed · 2 Moot · 28 Acknowledged.** Full per-issue rationale is tracked in a local `docs/audits/Bailsec-slisXAUE-fix.md` (intentionally **not** part of this PR).

## Verification

- `forge build` clean
- slisXAUE suite **54/54** (`forge test --match-path test/slisXAUE/SlisXAUE.t.sol`)
- `prettier --check` clean (pre-commit hook)

## Open operational items (no code)

Production role custody + TimeLock/Safe disclosure (01/02); permanent governance seed deposit (32/37, robustness for 05/10/28/29); BOT private-RPC + prompt-`acknowledgeReject` SLA (07/08); M-05 make-whole runbook (07); `minDeposit ≫ minWithdraw ≥` XAUE redeem-floor (09/27/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
