### PR TITLE
feat(AsterRewards): bot-automated notifyRewards via lisAsterManager + emergencyWithdraw

### DIFF
--- a/script/lisaster/upgrade_lisaster_rewards_v2_bsc.s.sol
+++ b/script/lisaster/upgrade_lisaster_rewards_v2_bsc.s.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+
+import { AsterRewards } from "../../src/lisaster/AsterRewards.sol";
+
+/// @title UpgradeAsterRewardsV2Bsc
+/// @notice BSC mainnet upgrade for the AsterRewards v2 proxy: `notifyRewards` becomes BOT-only and
+///         pulls from `lisAsterManager`; adds `emergencyWithdraw`. The deployer only deploys the
+///         new implementation; the UUPS upgrade and `setLisAsterManager` are ADMIN/MANAGER multisig
+///         transactions (this script prints their calldata).
+///
+///         Run: forge script script/lisaster/upgrade_lisaster_rewards_v2_bsc.s.sol:UpgradeAsterRewardsV2Bsc \
+///                --rpc-url bsc --broadcast --verify -vvvv
+contract UpgradeAsterRewardsV2Bsc is Script {
+  address constant ASTER_REWARDS_V2 = 0x935E18A52E24746fF7b4D307012D8A82C2AB5A23;
+  /// @dev DEFAULT_ADMIN multisig (executes upgradeToAndCall).
+  address constant ADMIN_MULTISIG = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
+  /// @dev MANAGER multisig (executes setLisAsterManager).
+  address constant MANAGER_MULTISIG = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+
+  function run() public {
+    require(block.chainid == 56, "expect BSC mainnet (chainId 56)");
+
+    uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+
+    vm.startBroadcast(deployerPk);
+    AsterRewards newImpl = new AsterRewards();
+    vm.stopBroadcast();
+
+    bytes memory upgradeCall = abi.encodeWithSignature("upgradeToAndCall(address,bytes)", address(newImpl), bytes(""));
+
+    console.log("New AsterRewards impl:   ", address(newImpl));
+    console.log("");
+    console.log("==== Step 1: ADMIN multisig tx ====");
+    console.log("from:", ADMIN_MULTISIG);
+    console.log("to:  ", ASTER_REWARDS_V2);
+    console.log('data (upgradeToAndCall(newImpl, "")):');
+    console.logBytes(upgradeCall);
+    console.log("");
+    console.log("==== Step 2: MANAGER multisig tx ====");
+    console.log("from:", MANAGER_MULTISIG);
+    console.log("to:  ", ASTER_REWARDS_V2);
+    console.log("call: setLisAsterManager(<lisAsterManager EOA / funding vault>)");
+    console.log("(fill the address, then the funding vault approves ASTER to the proxy)");
+  }
+}

--- a/src/lisaster/AsterRewards.sol
+++ b/src/lisaster/AsterRewards.sol
@@ -163,6 +163,16 @@ contract AsterRewards is
     _unpause();
   }
 
+  /// @notice MANAGER escape hatch for stuck / over-pulled ASTER or mis-sent tokens. Funds are
+  ///         sent to the MANAGER caller. Does not adjust accounting (this contract holds no
+  ///         cumulative state). BOT deliberately has no access.
+  function emergencyWithdraw(address token, uint256 amount) external onlyRole(MANAGER) {
+    require(token != address(0), "zero token");
+    require(amount > 0, "zero amount");
+    IERC20(token).safeTransfer(msg.sender, amount);
+    emit EmergencyWithdrawn(token, msg.sender, amount);
+  }
+
   /* UUPS */
   function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 }

--- a/src/lisaster/AsterRewards.sol
+++ b/src/lisaster/AsterRewards.sol
@@ -43,6 +43,12 @@ contract AsterRewards is
   address public feeReceiver;
   uint256 public feeRate; // 18 decimals (1e18 = 100%); MANAGER capped by MAX_FEE_RATE
 
+  /* REWARD SOURCE (MANAGER tunable; notifyRewards transferFrom source) */
+  /// @notice Lista-operated EOA on Astherus / Aster Chain; the ASTER reward source pulled by
+  ///         `notifyRewards`. Same entity/address as `AsterVault.lisAsterManager`. It must
+  ///         `approve` ASTER to this contract before BOT calls `notifyRewards`.
+  address public lisAsterManager;
+
   /* CONSTRUCTOR */
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
@@ -95,6 +101,14 @@ contract AsterRewards is
     require(r <= MAX_FEE_RATE, "feeRate too high");
     feeRate = r;
     emit SetFeeRate(r);
+  }
+
+  /* REWARD-SOURCE SETTER */
+  function setLisAsterManager(address newManager) external onlyRole(MANAGER) {
+    require(newManager != address(0), "lisAsterManager is zero");
+    address oldManager = lisAsterManager;
+    lisAsterManager = newManager;
+    emit SetLisAsterManager(oldManager, newManager);
   }
 
   /* EXTERNAL */

--- a/src/lisaster/AsterRewards.sol
+++ b/src/lisaster/AsterRewards.sol
@@ -12,10 +12,11 @@ import { ILisAsterDistributor } from "./interface/ILisAsterDistributor.sol";
 import { IAsterRewards } from "./interface/IAsterRewards.sol";
 
 /// @title AsterRewards
-/// @notice ASTER reward pool + dispatcher. MANAGER calls `notifyRewards` to ingest ASTER
-///         returned via AstherusVault.withdraw; an optional fee is forwarded to `feeReceiver`
-///         and the net stays here as ASTER. BOT calls `distributeRewards` to push accumulated
-///         ASTER to the Distributor, which pulls via `transferFrom` and bumps `totalNotified`.
+/// @notice ASTER reward pool + dispatcher. BOT calls `notifyRewards` to ingest ASTER from
+///         `lisAsterManager` (returned via AstherusVault.withdraw); an optional fee is forwarded
+///         to `feeReceiver` and the net stays here as ASTER. BOT calls `distributeRewards` to push
+///         accumulated ASTER to the Distributor, which pulls via `transferFrom` and bumps
+///         `totalNotified`.
 contract AsterRewards is
   IAsterRewards,
   AccessControlEnumerableUpgradeable,
@@ -112,10 +113,12 @@ contract AsterRewards is
   }
 
   /* EXTERNAL */
-  function notifyRewards(uint256 amount) external override onlyRole(MANAGER) whenNotPaused nonReentrant {
+  function notifyRewards(uint256 amount) external override onlyRole(BOT) whenNotPaused nonReentrant {
     require(amount > 0, "zero amount");
+    address src = lisAsterManager;
+    require(src != address(0), "lisAsterManager not set");
 
-    IERC20(asterToken).safeTransferFrom(msg.sender, address(this), amount);
+    IERC20(asterToken).safeTransferFrom(src, address(this), amount);
 
     // Take fee only when both knobs are configured. Either feeRate=0 or feeReceiver=0 means
     // no fee for this round -- MANAGER can stage the two settings in any order without

--- a/src/lisaster/interface/IAsterRewards.sol
+++ b/src/lisaster/interface/IAsterRewards.sol
@@ -7,6 +7,7 @@ interface IAsterRewards {
   event DistributorSet(address indexed distributor);
   event SetFeeReceiver(address indexed feeReceiver);
   event SetFeeRate(uint256 feeRate);
+  event SetLisAsterManager(address oldManager, address newManager);
 
   /// @notice MANAGER transfers ASTER in; `feeRate` of it is forwarded to `feeReceiver` and the
   ///         net stays in this contract as ASTER, awaiting `distributeRewards`.
@@ -21,6 +22,11 @@ interface IAsterRewards {
 
   /// @notice Set the fee rate (18 decimals, capped at `MAX_FEE_RATE`).
   function setFeeRate(uint256 r) external;
+
+  /// @notice Set the ASTER reward source (Lista-operated EOA on Astherus / Aster Chain).
+  ///         Required (non-zero) before BOT can call `notifyRewards`. Same entity/address as
+  ///         AsterVault.lisAsterManager.
+  function setLisAsterManager(address newManager) external;
 
   /// @notice ASTER currently held by this contract, ready to be forwarded to the Distributor.
   function pendingAster() external view returns (uint256);

--- a/src/lisaster/interface/IAsterRewards.sol
+++ b/src/lisaster/interface/IAsterRewards.sol
@@ -8,6 +8,7 @@ interface IAsterRewards {
   event SetFeeReceiver(address indexed feeReceiver);
   event SetFeeRate(uint256 feeRate);
   event SetLisAsterManager(address oldManager, address newManager);
+  event EmergencyWithdrawn(address indexed token, address indexed to, uint256 amount);
 
   /// @notice MANAGER transfers ASTER in; `feeRate` of it is forwarded to `feeReceiver` and the
   ///         net stays in this contract as ASTER, awaiting `distributeRewards`.
@@ -27,6 +28,10 @@ interface IAsterRewards {
   ///         Required (non-zero) before BOT can call `notifyRewards`. Same entity/address as
   ///         AsterVault.lisAsterManager.
   function setLisAsterManager(address newManager) external;
+
+  /// @notice MANAGER escape hatch: evacuate stuck/over-pulled ASTER or mis-sent tokens to the
+  ///         caller. Does not adjust accounting.
+  function emergencyWithdraw(address token, uint256 amount) external;
 
   /// @notice ASTER currently held by this contract, ready to be forwarded to the Distributor.
   function pendingAster() external view returns (uint256);

--- a/src/lisaster/interface/IAsterRewards.sol
+++ b/src/lisaster/interface/IAsterRewards.sol
@@ -10,8 +10,8 @@ interface IAsterRewards {
   event SetLisAsterManager(address oldManager, address newManager);
   event EmergencyWithdrawn(address indexed token, address indexed to, uint256 amount);
 
-  /// @notice MANAGER transfers ASTER in; `feeRate` of it is forwarded to `feeReceiver` and the
-  ///         net stays in this contract as ASTER, awaiting `distributeRewards`.
+  /// @notice BOT ingests ASTER pulled from `lisAsterManager`; `feeRate` of it is forwarded to
+  ///         `feeReceiver` and the net stays in this contract as ASTER, awaiting `distributeRewards`.
   function notifyRewards(uint256 amount) external;
 
   /// @notice BOT forwards accumulated ASTER to the Distributor and notifies it to update

--- a/test/lisAster/AsterRewards.t.sol
+++ b/test/lisAster/AsterRewards.t.sol
@@ -3,40 +3,66 @@ pragma solidity ^0.8.24;
 
 import { LisAsterBase } from "./LisAsterBase.t.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { AsterRewards } from "../../src/lisaster/AsterRewards.sol";
 
 contract AsterRewardsTest is LisAsterBase {
   /* ---------------- notifyRewards ---------------- */
 
   function test_notifyRewards_holdsAster() public {
-    asterToken.mint(manager, 5 ether);
-    vm.startPrank(manager);
-    asterToken.approve(address(rewards), 5 ether);
-    rewards.notifyRewards(5 ether);
-    vm.stopPrank();
+    _managerNotify(5 ether);
 
     // ASTER lands in Rewards. No Vault round-trip; no lisAster minted.
-    assertEq(asterToken.balanceOf(manager), 0);
+    assertEq(asterToken.balanceOf(lisAsterManager), 0);
     assertEq(asterToken.balanceOf(address(rewards)), 5 ether);
     assertEq(asterToken.balanceOf(address(astherusVault)), 0);
     assertEq(rewards.pendingAster(), 5 ether);
     assertEq(lisAster.totalSupply(), 0);
   }
 
-  function test_notifyRewards_onlyManager() public {
-    asterToken.mint(other, 1 ether);
-    vm.startPrank(other);
+  function test_notifyRewards_onlyBot() public {
+    asterToken.mint(lisAsterManager, 1 ether);
+    vm.prank(lisAsterManager);
     asterToken.approve(address(rewards), 1 ether);
-    vm.expectRevert(
-      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, other, rewards.MANAGER())
-    );
+
+    bytes32 botRole = rewards.BOT();
+    // MANAGER can no longer notify.
+    vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, manager, botRole));
+    vm.prank(manager);
     rewards.notifyRewards(1 ether);
-    vm.stopPrank();
+    // Random caller cannot notify.
+    vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, other, botRole));
+    vm.prank(other);
+    rewards.notifyRewards(1 ether);
+
+    // BOT can.
+    vm.prank(bot);
+    rewards.notifyRewards(1 ether);
+    assertEq(asterToken.balanceOf(address(rewards)), 1 ether);
   }
 
   function test_notifyRewards_revertsZero() public {
-    vm.prank(manager);
+    vm.prank(bot);
     vm.expectRevert(bytes("zero amount"));
     rewards.notifyRewards(0);
+  }
+
+  function test_notifyRewards_revertsWhenManagerUnset() public {
+    // Fresh Rewards proxy with no setLisAsterManager call.
+    AsterRewards fresh = AsterRewards(address(new ERC1967Proxy(address(new AsterRewards()), "")));
+    fresh.initialize(admin, pauser, manager, bot, address(asterToken));
+
+    vm.prank(bot);
+    vm.expectRevert(bytes("lisAsterManager not set"));
+    fresh.notifyRewards(1 ether);
+  }
+
+  function test_notifyRewards_revertsWithoutAllowance() public {
+    // lisAsterManager funded but did NOT approve Rewards.
+    asterToken.mint(lisAsterManager, 1 ether);
+    vm.prank(bot);
+    vm.expectRevert(); // ERC20InsufficientAllowance
+    rewards.notifyRewards(1 ether);
   }
 
   /* ---------------- distributeRewards ---------------- */
@@ -168,11 +194,7 @@ contract AsterRewardsTest is LisAsterBase {
   function test_notifyRewards_zeroFeeRate_noFeeTaken() public {
     // Default state: feeRate = 0, feeReceiver = 0. No fee path.
     address recipient = makeAddr("feeRecipient");
-    asterToken.mint(manager, 10 ether);
-    vm.startPrank(manager);
-    asterToken.approve(address(rewards), 10 ether);
-    rewards.notifyRewards(10 ether);
-    vm.stopPrank();
+    _managerNotify(10 ether);
 
     assertEq(asterToken.balanceOf(recipient), 0, "no fee taken");
     assertEq(asterToken.balanceOf(address(rewards)), 10 ether, "all retained");
@@ -185,11 +207,7 @@ contract AsterRewardsTest is LisAsterBase {
     rewards.setFeeRate(1e17); // 10%
     vm.stopPrank();
 
-    asterToken.mint(manager, 10 ether);
-    vm.startPrank(manager);
-    asterToken.approve(address(rewards), 10 ether);
-    rewards.notifyRewards(10 ether);
-    vm.stopPrank();
+    _managerNotify(10 ether);
 
     // 10% fee = 1 ASTER to recipient, 9 ASTER stays in Rewards as ASTER.
     assertEq(asterToken.balanceOf(recipient), 1 ether, "fee transferred");
@@ -200,11 +218,7 @@ contract AsterRewardsTest is LisAsterBase {
     vm.prank(manager);
     rewards.setFeeRate(1e17); // 10%
 
-    asterToken.mint(manager, 10 ether);
-    vm.startPrank(manager);
-    asterToken.approve(address(rewards), 10 ether);
-    rewards.notifyRewards(10 ether);
-    vm.stopPrank();
+    _managerNotify(10 ether);
 
     // No fee transferred anywhere; full 10 ether retained.
     assertEq(asterToken.balanceOf(address(rewards)), 10 ether);
@@ -215,11 +229,7 @@ contract AsterRewardsTest is LisAsterBase {
     vm.prank(manager);
     rewards.setFeeReceiver(recipient);
 
-    asterToken.mint(manager, 10 ether);
-    vm.startPrank(manager);
-    asterToken.approve(address(rewards), 10 ether);
-    rewards.notifyRewards(10 ether);
-    vm.stopPrank();
+    _managerNotify(10 ether);
 
     assertEq(asterToken.balanceOf(recipient), 0);
     assertEq(asterToken.balanceOf(address(rewards)), 10 ether);
@@ -232,11 +242,7 @@ contract AsterRewardsTest is LisAsterBase {
     rewards.setFeeRate(rewards.MAX_FEE_RATE()); // 30%
     vm.stopPrank();
 
-    asterToken.mint(manager, 10 ether);
-    vm.startPrank(manager);
-    asterToken.approve(address(rewards), 10 ether);
-    rewards.notifyRewards(10 ether);
-    vm.stopPrank();
+    _managerNotify(10 ether);
 
     assertEq(asterToken.balanceOf(recipient), 3 ether);
     assertEq(asterToken.balanceOf(address(rewards)), 7 ether);

--- a/test/lisAster/AsterRewards.t.sol
+++ b/test/lisAster/AsterRewards.t.sol
@@ -94,6 +94,27 @@ contract AsterRewardsTest is LisAsterBase {
     rewards.setDistributor(address(0xDEAD));
   }
 
+  /* ---------------- setLisAsterManager ---------------- */
+
+  function test_setLisAsterManager_byManager() public {
+    vm.prank(manager);
+    rewards.setLisAsterManager(other);
+    assertEq(rewards.lisAsterManager(), other);
+  }
+
+  function test_setLisAsterManager_revertsZero() public {
+    vm.prank(manager);
+    vm.expectRevert(bytes("lisAsterManager is zero"));
+    rewards.setLisAsterManager(address(0));
+  }
+
+  function test_setLisAsterManager_onlyManager() public {
+    bytes32 role = rewards.MANAGER();
+    vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, role));
+    vm.prank(admin);
+    rewards.setLisAsterManager(other);
+  }
+
   /* ---------------- fee setters ---------------- */
 
   function test_setFeeReceiver_byManager() public {

--- a/test/lisAster/AsterRewards.t.sol
+++ b/test/lisAster/AsterRewards.t.sol
@@ -248,6 +248,38 @@ contract AsterRewardsTest is LisAsterBase {
     assertEq(asterToken.balanceOf(address(rewards)), 7 ether);
   }
 
+  /* ---------------- emergencyWithdraw ---------------- */
+
+  function test_emergencyWithdraw_byManager() public {
+    _managerNotify(5 ether);
+    uint256 balBefore = asterToken.balanceOf(address(rewards));
+
+    vm.prank(manager);
+    rewards.emergencyWithdraw(address(asterToken), 2 ether);
+
+    // Funds go to the MANAGER caller.
+    assertEq(asterToken.balanceOf(manager), 2 ether);
+    assertEq(asterToken.balanceOf(address(rewards)), balBefore - 2 ether);
+  }
+
+  function test_emergencyWithdraw_onlyManager() public {
+    _managerNotify(1 ether);
+    // BOT explicitly cannot evacuate funds.
+    bytes32 role = rewards.MANAGER();
+    vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, bot, role));
+    vm.prank(bot);
+    rewards.emergencyWithdraw(address(asterToken), 1 ether);
+  }
+
+  function test_emergencyWithdraw_zeroChecks() public {
+    vm.startPrank(manager);
+    vm.expectRevert(bytes("zero token"));
+    rewards.emergencyWithdraw(address(0), 1 ether);
+    vm.expectRevert(bytes("zero amount"));
+    rewards.emergencyWithdraw(address(asterToken), 0);
+    vm.stopPrank();
+  }
+
   /* ---------------- pause / unpause ---------------- */
 
   function test_pause_byPauser() public {

--- a/test/lisAster/LisAsterBase.t.sol
+++ b/test/lisAster/LisAsterBase.t.sol
@@ -78,6 +78,10 @@ abstract contract LisAsterBase is Test {
     // 3. Rewards one-shot setDistributor (MANAGER-gated; only Rewards still wires distributor on-chain).
     vm.prank(manager);
     rewards.setDistributor(address(distributor));
+
+    // 4. Configure the ASTER reward source so BOT can notifyRewards.
+    vm.prank(manager);
+    rewards.setLisAsterManager(lisAsterManager);
   }
 
   /* ----------------- helpers ----------------- */
@@ -94,14 +98,14 @@ abstract contract LisAsterBase is Test {
     vm.stopPrank();
   }
 
-  /// @dev Rewards.MANAGER receives ASTER returned via Astherus and stages it in Rewards as
-  ///      ASTER (no more Vault round-trip).
+  /// @dev Inject `amount` ASTER into Rewards under the bot-automated flow: lisAsterManager funds
+  ///      and approves, BOT calls notifyRewards. (Name kept for call-site stability.)
   function _managerNotify(uint256 amount) internal {
-    asterToken.mint(manager, amount);
-    vm.startPrank(manager);
+    asterToken.mint(lisAsterManager, amount);
+    vm.prank(lisAsterManager);
     asterToken.approve(address(rewards), amount);
+    vm.prank(bot);
     rewards.notifyRewards(amount);
-    vm.stopPrank();
   }
 
   /// @dev BOT pushes ASTER from Rewards to Distributor and triggers notify.


### PR DESCRIPTION
## Summary
- `notifyRewards`: `onlyRole(MANAGER)` → `onlyRole(BOT)`; the funding source changes from `msg.sender` to a new configurable `lisAsterManager` (the Lista-operated EOA that is `AsterVault`'s `forAddress` and the on-chain landing spot for ASTER returned from Astherus). BOT can now notify on a hot key; the funding side only needs to `approve` periodically.
- Add `lisAsterManager` state var (appended at slot 4) + `setLisAsterManager(MANAGER)`, mirroring `AsterVault`'s same-named setter/event.
- Add `emergencyWithdraw(token, amount)` (`onlyRole(MANAGER)`, sends to the caller), mirroring the audited `LisAsterDistributor.emergencyWithdraw`.
- Add a BSC mainnet upgrade script (deploys the new impl + prints ADMIN/MANAGER multisig calldata).
- `LisAsterDistributor` is unchanged.

## Storage & upgrade safety
- OZ upgradeable 5.1.0 (ERC-7201). `forge inspect` confirms slots 0–3 (`asterToken`/`distributor`/`feeReceiver`/`feeRate`) are unchanged; `lisAsterManager` is appended at slot 4.
- UUPS: `upgradeToAndCall(newImpl, "")` (empty calldata, no reinitializer) + MANAGER `setLisAsterManager`. Between the upgrade and configuration, `notifyRewards` reverts with `lisAsterManager not set` (a safe closed state).

## Security
- BOT has no `emergencyWithdraw`; ASTER can only move via `distributeRewards → Distributor → merkle claim` (6h timelock + MANAGER `revoke`). A compromised BOT can at worst notify early — it cannot steal funds. The real gate is how much `lisAsterManager` approves (approve on demand).
- `emergencyWithdraw` only widens the trusted MANAGER multisig's recovery ability; it does not widen the BOT attack surface.

## Test Plan
- [x] `forge test` — 211 passing (new/updated: `onlyBot`, `revertsWhenManagerUnset`, `revertsWithoutAllowance`, `setLisAsterManager_*`, `emergencyWithdraw_*`; fee suite + invariant I-3 re-checked).
- [x] Storage layout verified (slots 0–3 unchanged, slot 4 = `lisAsterManager`).
- [ ] Mainnet runbook: ADMIN multisig `upgradeToAndCall(impl, "")` → MANAGER `setLisAsterManager(<EOA>)` → funding EOA `approve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)