### PR TITLE
chore(oracle): swap Atlas adaptor deploy list to tokenized-equity feeds

### DIFF
--- a/script/oracle/deployAtlasOracleAdaptors.sol
+++ b/script/oracle/deployAtlasOracleAdaptors.sol
@@ -23,29 +23,14 @@ contract DeployAtlasOracleAdaptors is Script {
     address deployer = vm.addr(deployerPrivateKey);
     console.log("Deployer:", deployer);
 
-    Feed[20] memory feeds = [
-      // ----- Feeds 719-731 (new tokens, replacing BinanceOracle) -----
-      Feed("B2/USD", 0xd6cF91a4D545462821A43997A6df104c5068D71D), // feed 719
-      Feed("B/USD", 0x2BcDFbc731FD179c70794854a4260774369c8d27), // feed 720
-      Feed("CDL/USD", 0x5036F6F0b618B5eB12452b9FC782c8D2E5e996c9), // feed 721
-      Feed("SPA/USD", 0x9a97167364dD00F8Bc52e346Ccb8d603e0b9A740), // feed 722
-      Feed("ASTER/USD", 0xEE9483FD2d380384d42326143f4bc9Bd0513234d), // feed 723
-      Feed("AB/USD", 0xfF45B658838fb3Afa2d00CCa5033258C262F98De), // feed 724
-      Feed("TAKE/USD", 0x61e4BE67372e5dFF1B8539cc5441B170ede68A48), // feed 725
-      Feed("PUFFER/USD", 0x2BC9c150981D74E24b85C3d714852631928599B4), // feed 726
-      Feed("WLFI/USD", 0x6eBa8B28f2411AB14f7ecDC3A2477ad436AcbD21), // feed 727
-      Feed("OIK/USD", 0xfe9A5337dA82a0fc8476C2A1EDc292d729d29f71), // feed 728
-      Feed("AT/USD", 0x8b8678dC64b7539A59E68e25d10cb2846F0918fE), // feed 729
-      Feed("EGL1/USD", 0xe659636dbe70E9a53f7762D9eEF385A4fA528475), // feed 730
-      Feed("ANKR/USD", 0xEd2ce62b7BFDD31876B1e956a672e8fBE8b29403), // feed 731
-      // ----- Shared / additional feeds (used by multiple assets in ResilientOracle) -----
-      Feed("FDUSD/USD", 0x122589967CbE77Dd6061D212D198ca45F77fd02c), // feed 732
-      Feed("CAKE/USD", 0x55aD1D026D1bC49939b0bA9A451E393c79ad8e93), // feed 733
-      Feed("BNB/USD", 0x9C0517F5b4c8657c7F18D68d2d79e2b3b1cd6438), // feed 633
-      Feed("ETH/USD", 0x7942b8DD9f552c57Eb94D16ea8215aEf6CAc948f), // feed 632
-      Feed("BTCB/USD", 0x4f6c53fb9CdD46269d24bCa4E68bB680879132fc), // feed 626 (also used by solvBTC, SolvBTC.DLP, pumpBTC, mBTC)
-      Feed("USDT/USD", 0x9Fc000FC9C17578b49853278A517e357201D01e4), // feed 649 (also used by USDF)
-      Feed("USDe/USD", 0x802694092E220AD7C180AC8572B6148B2F409be6) // feed 638
+    Feed[6] memory feeds = [
+      // ----- Atlas tokenized-equity / RWA push feeds -----
+      Feed("TSLAB/USD", 0xC64bF44C23586aE5eab37775662Dc1E0c56469fe),
+      Feed("NVDAB/USD", 0x67d168bF5d7851a7b361bFFcf794696858F9697A),
+      Feed("SNDKB/USD", 0xEb856d62Bdf5b00C5a62c44B3fF94caF5F5d32DC),
+      Feed("CRCLB/USD", 0x3Fe4Ad1BBb3ad138AA7d8a63a9A2984eC9641064),
+      Feed("MUB/USD", 0xcC8d5Ffd711A85775EECB4EcE319eDDCC5EeBCE5),
+      Feed("SPCXB/USD", 0xCf5D24C987caCD4155C83aBB95fA86951D3832f9)
     ];
 
     vm.startBroadcast(deployerPrivateKey);


### PR DESCRIPTION
## Summary

Swap the deploy list in `deployAtlasOracleAdaptors.sol` to the new batch of Atlas tokenized-equity / RWA push feeds (TSLAB, NVDAB, SNDKB, CRCLB, MUB, SPCXB) so a `--broadcast` run deploys exactly one `AtlasOracleAdaptor` per new feed. The previously-deployed 20-feed batch is removed so a re-run does not redeploy duplicate adaptors; those addresses remain in git history.

## Change type

- [ ] New contract
- [ ] Upgrade (existing proxy)
- [ ] Bug fix
- [ ] Gas optimization
- [ ] Configuration change
- [x] Migration / deploy script
- [ ] Test
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| `DeployAtlasOracleAdaptors` (script) | `script/oracle/deployAtlasOracleAdaptors.sol` | modified |

No production contract changed — `src/oracle/AtlasOracleAdaptor.sol` is untouched.

## Interface changes

None. Only the `feeds` array contents and its fixed size (`Feed[20]` → `Feed[6]`) changed; the deployment loop and the `AtlasOracleAdaptor` constructor are unchanged.

## Storage layout

N/A — deploy script only; no upgradeable/stateful contract changed.

## Access control

Unchanged.

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | No contract storage touched. |
| Fund safety | 🟢 None | Script only deploys read-only oracle adaptors; no funds handled. |
| Access control | 🟢 None | No roles/owners changed. |
| External call safety | 🟡 Low | The adaptor constructor calls `decimals()` on each feed and reverts unless it returns 18, so a wrong/non-18-decimal address fails fast at deploy time rather than producing a bad adaptor. Feed addresses must be the correct Atlas push feeds. |

## Deployment

- **Chain:** BSC
- **Script:** `script/oracle/deployAtlasOracleAdaptors.sol:DeployAtlasOracleAdaptors`
- **Env:** `DEPLOYER_PRIVATE_KEY`, `BSC_RPC`
- **Command:**
  ```
  forge script script/oracle/deployAtlasOracleAdaptors.sol:DeployAtlasOracleAdaptors \
    --rpc-url $BSC_RPC --broadcast --slow -vvvv
  ```
- **Feeds (EIP-55 checksummed):**

  | Symbol | Atlas push feed |
  |---|---|
  | TSLAB/USD | `0xC64bF44C23586aE5eab37775662Dc1E0c56469fe` |
  | NVDAB/USD | `0x67d168bF5d7851a7b361bFFcf794696858F9697A` |
  | SNDKB/USD | `0xEb856d62Bdf5b00C5a62c44B3fF94caF5F5d32DC` |
  | CRCLB/USD | `0x3Fe4Ad1BBb3ad138AA7d8a63a9A2984eC9641064` |
  | MUB/USD | `0xcC8d5Ffd711A85775EECB4EcE319eDDCC5EeBCE5` |
  | SPCXB/USD | `0xCf5D24C987caCD4155C83aBB95fA86951D3832f9` |

## Test plan

- [x] `forge build` passes (`Compiler run successful!`)
- [ ] `forge test` not run — deploy-script-only change, no contract logic modified, so the existing suite is unaffected
- [ ] Post-deploy: verify each adaptor's immutable `atlasFeed` matches the intended push feed and `decimals()` returns 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
