### PR TITLE
feat(oracle): add tokenized-equity Atlas adaptors (MSTRB/INTCB/EWYB/AMDB)

### DIFF
--- a/script/oracle/deployAtlasOracleAdaptors.sol
+++ b/script/oracle/deployAtlasOracleAdaptors.sol
@@ -23,14 +23,19 @@ contract DeployAtlasOracleAdaptors is Script {
     address deployer = vm.addr(deployerPrivateKey);
     console.log("Deployer:", deployer);
 
-    Feed[6] memory feeds = [
-      // ----- Atlas tokenized-equity / RWA push feeds -----
-      Feed("TSLAB/USD", 0xC64bF44C23586aE5eab37775662Dc1E0c56469fe),
-      Feed("NVDAB/USD", 0x67d168bF5d7851a7b361bFFcf794696858F9697A),
-      Feed("SNDKB/USD", 0xEb856d62Bdf5b00C5a62c44B3fF94caF5F5d32DC),
-      Feed("CRCLB/USD", 0x3Fe4Ad1BBb3ad138AA7d8a63a9A2984eC9641064),
-      Feed("MUB/USD", 0xcC8d5Ffd711A85775EECB4EcE319eDDCC5EeBCE5),
-      Feed("SPCXB/USD", 0xCf5D24C987caCD4155C83aBB95fA86951D3832f9)
+    Feed[4] memory feeds = [
+      // ----- Atlas tokenized-equity / RWA push feeds (already deployed) -----
+      // Feed("TSLAB/USD", 0xC64bF44C23586aE5eab37775662Dc1E0c56469fe),
+      // Feed("NVDAB/USD", 0x67d168bF5d7851a7b361bFFcf794696858F9697A),
+      // Feed("SNDKB/USD", 0xEb856d62Bdf5b00C5a62c44B3fF94caF5F5d32DC),
+      // Feed("CRCLB/USD", 0x3Fe4Ad1BBb3ad138AA7d8a63a9A2984eC9641064),
+      // Feed("MUB/USD", 0xcC8d5Ffd711A85775EECB4EcE319eDDCC5EeBCE5),
+      // Feed("SPCXB/USD", 0xCf5D24C987caCD4155C83aBB95fA86951D3832f9)
+      // ----- New tokenized-equity push feeds -----
+      Feed("MSTRB/USD", 0x5453B1ABf6029A5d05De56D48d3a835Df80b7A7f),
+      Feed("INTCB/USD", 0x04676ef12A9787761DDd0d1e27522c4a65b64262),
+      Feed("EWYB/USD", 0xEb8AeD013806f9682a8B4530Ae3E9CE47F3f76B5),
+      Feed("AMDB/USD", 0xBF0D0cDb25bc20C809190836b14AE902AEc17EaC)
     ];
 
     vm.startBroadcast(deployerPrivateKey);


### PR DESCRIPTION
## Summary
Deploy `AtlasOracleAdaptor` for 4 new tokenized-equity Atlas push feeds.

| Symbol | Push contract |
|--------|---------------|
| MSTRB/USD | `0x5453B1ABf6029A5d05De56D48d3a835Df80b7A7f` |
| INTCB/USD | `0x04676ef12A9787761DDd0d1e27522c4a65b64262` |
| EWYB/USD  | `0xEb8AeD013806f9682a8B4530Ae3E9CE47F3f76B5` |
| AMDB/USD  | `0xBF0D0cDb25bc20C809190836b14AE902AEc17EaC` |

## Changes
- Comment out the 6 already-deployed RWA push feeds (TSLAB/NVDAB/SNDKB/CRCLB/MUB/SPCXB).
- Add the 4 new feeds above; `Feed[6]` -> `Feed[4]`.
- Addresses checksummed to EIP-55.

## Test
- `forge build` clean (Solc 0.8.24).