### PR TITLE
feat(oracle): add non-upgradable LisAsterPriceFeed (ASTER x 0.8)

### DIFF
--- a/script/oracle/deployLisAsterPriceFeed.sol
+++ b/script/oracle/deployLisAsterPriceFeed.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Script.sol";
+
+import { LisAsterPriceFeed } from "@src/oracle/LisAsterPriceFeed.sol";
+import "@src/oracle/interfaces/OracleInterface.sol";
+
+/**
+ * @title DeployLisAsterPriceFeed
+ * @notice Deploys the non-upgradable LisAsterPriceFeed. Both the ResilientOracle
+ * source and the ASTER token address are hardcoded in the contract, so there is
+ * nothing to configure at deploy time.
+ * Run with:
+ *   forge script script/oracle/deployLisAsterPriceFeed.sol:DeployLisAsterPriceFeed \
+ *     --rpc-url bsc --private-key $DEPLOYER_PRIVATE_KEY --broadcast --verify -vvvv
+ */
+contract DeployLisAsterPriceFeed is Script {
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer:", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    LisAsterPriceFeed feed = new LisAsterPriceFeed();
+
+    vm.stopBroadcast();
+
+    console.log("LisAsterPriceFeed deployed ->", address(feed));
+    console.log("  ASTER (1e8):", OracleInterface(feed.RESILIENT_ORACLE()).peek(feed.ASTER()));
+    console.log("  lisAster (1e8):", uint256(feed.latestAnswer()));
+  }
+}

--- a/src/oracle/LisAsterPriceFeed.sol
+++ b/src/oracle/LisAsterPriceFeed.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "./interfaces/OracleInterface.sol";
+import "./libraries/FullMath.sol";
+
+/**
+ * @title LisAsterPriceFeed
+ * @author Lista
+ * @notice Non-upgradable price feed for lisAster.
+ *
+ * The lisAster main price source is derived purely from the ASTER price with a
+ * fixed haircut: `lisAster = ASTER * 0.8`. It deliberately does NOT read the
+ * lisAster secondary-market price. The ASTER price is sourced from the Lista
+ * ResilientOracle (`peek`), which returns an 8-decimal USD price and enforces
+ * its own staleness / bound validation upstream.
+ *
+ * @dev Exposes an 8-decimal `AggregatorV3Interface` so it can be plugged into a
+ * downstream ResilientOracle as lisAster's main feed, mirroring
+ * {AtlasOracleAdaptor}. Both dependency addresses are hardcoded immutables and
+ * the contract has no admin, so the discount ratio and price source can never
+ * be changed after deployment.
+ */
+contract LisAsterPriceFeed is AggregatorV3Interface {
+  /// @notice Lista ResilientOracle providing the ASTER USD price (8 decimals) via `peek`.
+  OracleInterface public constant RESILIENT_ORACLE = OracleInterface(0xf3afD82A4071f272F403dC176916141f44E6c750);
+
+  /// @notice ASTER token address used as the `peek` key into the ResilientOracle.
+  address public constant ASTER = 0x000Ae314E2A2172a039B26378814C252734f556A;
+
+  /// @notice Fixed lisAster discount, expressed in basis points (8000 = 80%).
+  uint256 public constant DISCOUNT_BPS = 8000;
+  /// @notice Basis-point denominator.
+  uint256 public constant BPS_DENOMINATOR = 10000;
+
+  function decimals() external pure returns (uint8) {
+    return 8;
+  }
+
+  function description() external pure returns (string memory) {
+    return "lisAster / USD";
+  }
+
+  function version() external pure returns (uint256) {
+    return 1;
+  }
+
+  function latestAnswer() external view returns (int256) {
+    return int256(_price());
+  }
+
+  function getRoundData(
+    uint80 _roundId
+  )
+    external
+    view
+    returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+  {
+    return (_roundId, int256(_price()), block.timestamp, block.timestamp, _roundId);
+  }
+
+  function latestRoundData()
+    external
+    view
+    returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+  {
+    return (1, int256(_price()), block.timestamp, block.timestamp, 1);
+  }
+
+  /**
+   * @dev Fetch the ASTER price from the ResilientOracle and apply the fixed 0.8
+   * discount. `peek` returns an 8-decimal USD price and reverts / returns 0 on an
+   * invalid price; the multiplication preserves the 8-decimal scale. FullMath is
+   * used to avoid intermediate overflow, though it cannot occur at realistic prices.
+   */
+  function _price() internal view returns (uint256) {
+    uint256 asterPrice = RESILIENT_ORACLE.peek(ASTER);
+    return FullMath.mulDiv(asterPrice, DISCOUNT_BPS, BPS_DENOMINATOR);
+  }
+}

--- a/test/oracle/LisAsterPriceFeed.t.sol
+++ b/test/oracle/LisAsterPriceFeed.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import { LisAsterPriceFeed } from "@src/oracle/LisAsterPriceFeed.sol";
+import "@src/oracle/interfaces/OracleInterface.sol";
+
+contract LisAsterPriceFeedTest is Test {
+  LisAsterPriceFeed feed;
+
+  address constant RESILIENT_ORACLE = 0xf3afD82A4071f272F403dC176916141f44E6c750;
+  address constant ASTER = 0x000Ae314E2A2172a039B26378814C252734f556A;
+
+  function setUp() public {
+    vm.createSelectFork("https://bsc-dataseed.binance.org");
+    feed = new LisAsterPriceFeed();
+  }
+
+  function test_metadata() public {
+    assertEq(feed.decimals(), 8);
+    assertEq(feed.version(), 1);
+    assertEq(feed.description(), "lisAster / USD");
+    assertEq(address(feed.RESILIENT_ORACLE()), RESILIENT_ORACLE);
+    assertEq(feed.ASTER(), ASTER);
+    assertEq(feed.DISCOUNT_BPS(), 8000);
+    assertEq(feed.BPS_DENOMINATOR(), 10000);
+  }
+
+  function test_latestAnswer_isAsterTimes0_8() public {
+    uint256 asterPrice = OracleInterface(RESILIENT_ORACLE).peek(ASTER);
+    assertGt(asterPrice, 0, "aster price should be live on fork");
+
+    uint256 expected = (asterPrice * 8000) / 10000;
+    assertEq(uint256(feed.latestAnswer()), expected);
+
+    (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = feed
+      .latestRoundData();
+    assertEq(roundId, 1);
+    assertEq(uint256(answer), expected);
+    assertEq(startedAt, block.timestamp);
+    assertEq(updatedAt, block.timestamp);
+    assertEq(answeredInRound, 1);
+
+    console.log("ASTER   (1e8):", asterPrice);
+    console.log("lisAster(1e8):", expected);
+  }
+
+  function test_derivesFromAsterOnly_mockedSource() public {
+    // Overwrite the ASTER peek result and confirm the feed tracks it at exactly 0.8x.
+    uint256 mockAster = 1_00000000; // $1.00 @ 8 decimals
+    vm.mockCall(RESILIENT_ORACLE, abi.encodeWithSelector(OracleInterface.peek.selector, ASTER), abi.encode(mockAster));
+
+    assertEq(uint256(feed.latestAnswer()), 80000000); // $0.80
+
+    vm.mockCall(
+      RESILIENT_ORACLE,
+      abi.encodeWithSelector(OracleInterface.peek.selector, ASTER),
+      abi.encode(uint256(2_00000000))
+    );
+    assertEq(uint256(feed.latestAnswer()), 160000000); // $1.60
+  }
+}


### PR DESCRIPTION
## Summary

Adds `LisAsterPriceFeed`, a non-upgradable oracle for lisAster.

**lisAster price = ASTER price × 0.8** (fixed haircut). ASTER is read from the Lista ResilientOracle via `peek` (8-decimal USD); the lisAster secondary-market price is deliberately **not** used. Exposes an 8-decimal `AggregatorV3Interface`, mirroring `AtlasOracleAdaptor`, so it can plug into a downstream ResilientOracle as lisAster's main feed.

## Details

- Both dependency addresses are hardcoded `constant`s — no admin, no upgrade path:
  - ResilientOracle: `0xf3afD82A4071f272F403dC176916141f44E6c750`
  - ASTER token: `0x000Ae314E2A2172a039B26378814C252734f556A`
- Discount applied in basis points (`8000 / 10000`) via `FullMath.mulDiv`; output stays at 8 decimals.

## Files

- `src/oracle/LisAsterPriceFeed.sol` — the feed
- `test/oracle/LisAsterPriceFeed.t.sol` — BSC fork tests
- `script/oracle/deployLisAsterPriceFeed.sol` — BSC deploy script

## Testing

- `forge test --match-contract LisAsterPriceFeedTest` → 3 passed. Live on fork: ASTER `64082284` → lisAster `51265827` (~$0.64 → ~$0.51).
- Deploy script dry-run on BSC mainnet (chain 56) succeeds.