### PR TITLE
feat(oracle): add batch3 Atlas oracle adaptors (MSFTB/METAB/PLTRB/LITEB/QQQB)

### DIFF
--- a/script/oracle/deployAtlasOracleAdaptors.sol
+++ b/script/oracle/deployAtlasOracleAdaptors.sol
@@ -23,7 +23,7 @@ contract DeployAtlasOracleAdaptors is Script {
     address deployer = vm.addr(deployerPrivateKey);
     console.log("Deployer:", deployer);
 
-    Feed[4] memory feeds = [
+    Feed[5] memory feeds = [
       // ----- Atlas tokenized-equity / RWA push feeds (already deployed) -----
       // Feed("TSLAB/USD", 0xC64bF44C23586aE5eab37775662Dc1E0c56469fe),
       // Feed("NVDAB/USD", 0x67d168bF5d7851a7b361bFFcf794696858F9697A),
@@ -31,11 +31,16 @@ contract DeployAtlasOracleAdaptors is Script {
       // Feed("CRCLB/USD", 0x3Fe4Ad1BBb3ad138AA7d8a63a9A2984eC9641064),
       // Feed("MUB/USD", 0xcC8d5Ffd711A85775EECB4EcE319eDDCC5EeBCE5),
       // Feed("SPCXB/USD", 0xCf5D24C987caCD4155C83aBB95fA86951D3832f9)
+      // Feed("MSTRB/USD", 0x5453B1ABf6029A5d05De56D48d3a835Df80b7A7f),
+      // Feed("INTCB/USD", 0x04676ef12A9787761DDd0d1e27522c4a65b64262),
+      // Feed("EWYB/USD", 0xEb8AeD013806f9682a8B4530Ae3E9CE47F3f76B5),
+      // Feed("AMDB/USD", 0xBF0D0cDb25bc20C809190836b14AE902AEc17EaC)
       // ----- New tokenized-equity push feeds -----
-      Feed("MSTRB/USD", 0x5453B1ABf6029A5d05De56D48d3a835Df80b7A7f),
-      Feed("INTCB/USD", 0x04676ef12A9787761DDd0d1e27522c4a65b64262),
-      Feed("EWYB/USD", 0xEb8AeD013806f9682a8B4530Ae3E9CE47F3f76B5),
-      Feed("AMDB/USD", 0xBF0D0cDb25bc20C809190836b14AE902AEc17EaC)
+      Feed("MSFTB/USD", 0xe39fC955A9b926d5ce0242505006611678180307),
+      Feed("METAB/USD", 0xD53300F42830552D826244fc17a6A0a4a95980A6),
+      Feed("PLTRB/USD", 0x485568bd19d587fF67F465EEff135C1F0745751C),
+      Feed("LITEB/USD", 0x617EC012e45B864d140d3F3B3912DDa210979ea5),
+      Feed("QQQB/USD", 0x7D2f703D2A188f32310dC9707E86acE503207027)
     ];
 
     vm.startBroadcast(deployerPrivateKey);


### PR DESCRIPTION
## Summary
Add batch3 tokenized-equity Atlas oracle push feeds to the deploy script.

- Array resized `Feed[4]` → `Feed[5]`
- Batch2 (MSTRB/INTCB/EWYB/AMDB) moved to commented "already deployed" section
- New feeds (checksummed addresses):

| Symbol | Push contract |
|---|---|
| MSFTB/USD | `0xe39fC955A9b926d5ce0242505006611678180307` |
| METAB/USD | `0xD53300F42830552D826244fc17a6A0a4a95980A6` |
| PLTRB/USD | `0x485568bd19d587fF67F465EEff135C1F0745751C` |
| LITEB/USD | `0x617EC012e45B864d140d3F3B3912DDa210979ea5` |
| QQQB/USD | `0x7D2f703D2A188f32310dC9707E86acE503207027` |

## Test
`forge build` — compiler run successful (Solc 0.8.24).