### PR TITLE
feat(oracle): add batch4 Atlas oracle adaptors (10 tokenized-equity feeds)

### DIFF
--- a/script/oracle/deployAtlasOracleAdaptors.sol
+++ b/script/oracle/deployAtlasOracleAdaptors.sol
@@ -23,7 +23,7 @@ contract DeployAtlasOracleAdaptors is Script {
     address deployer = vm.addr(deployerPrivateKey);
     console.log("Deployer:", deployer);
 
-    Feed[5] memory feeds = [
+    Feed[10] memory feeds = [
       // ----- Atlas tokenized-equity / RWA push feeds (already deployed) -----
       // Feed("TSLAB/USD", 0xC64bF44C23586aE5eab37775662Dc1E0c56469fe),
       // Feed("NVDAB/USD", 0x67d168bF5d7851a7b361bFFcf794696858F9697A),
@@ -35,12 +35,23 @@ contract DeployAtlasOracleAdaptors is Script {
       // Feed("INTCB/USD", 0x04676ef12A9787761DDd0d1e27522c4a65b64262),
       // Feed("EWYB/USD", 0xEb8AeD013806f9682a8B4530Ae3E9CE47F3f76B5),
       // Feed("AMDB/USD", 0xBF0D0cDb25bc20C809190836b14AE902AEc17EaC)
-      // ----- New tokenized-equity push feeds -----
-      Feed("MSFTB/USD", 0xe39fC955A9b926d5ce0242505006611678180307),
-      Feed("METAB/USD", 0xD53300F42830552D826244fc17a6A0a4a95980A6),
-      Feed("PLTRB/USD", 0x485568bd19d587fF67F465EEff135C1F0745751C),
-      Feed("LITEB/USD", 0x617EC012e45B864d140d3F3B3912DDa210979ea5),
-      Feed("QQQB/USD", 0x7D2f703D2A188f32310dC9707E86acE503207027)
+      // ----- Batch 3 tokenized-equity push feeds (already deployed) -----
+      // Feed("MSFTB/USD", 0xe39fC955A9b926d5ce0242505006611678180307),
+      // Feed("METAB/USD", 0xD53300F42830552D826244fc17a6A0a4a95980A6),
+      // Feed("PLTRB/USD", 0x485568bd19d587fF67F465EEff135C1F0745751C),
+      // Feed("LITEB/USD", 0x617EC012e45B864d140d3F3B3912DDa210979ea5),
+      // Feed("QQQB/USD", 0x7D2f703D2A188f32310dC9707E86acE503207027)
+      // ----- Batch 4 tokenized-equity push feeds -----
+      Feed("CBRSB/USD", 0xB3FC5F9187EBE4640985E6607DDe7DE1C7067B04),
+      Feed("COINB/USD", 0x758aB25F2Db37AAE2CC09D5542B2C69b5fC70E61),
+      Feed("DRAMB/USD", 0x6eaed198cA7d86C7982C30CAC4dc1c28BE915744),
+      Feed("GLWB/USD", 0x60014fD4FcdB9778C771f510BC6F1abBa824c8f6),
+      Feed("GOOGLB/USD", 0x2FcEafD81a4dBDa2409B6fe5ce2afFe3cD46eDbC),
+      Feed("NBISB/USD", 0x50f67D3CE440A98fFeC832726260ae03667fbE5E),
+      Feed("QCOMB/USD", 0x22772c763Fc2B44eD59Da2BD309Fa8E4D00261f5),
+      Feed("SOXLB/USD", 0xbFC8C863B14f08e07e789328A424137E2B5933F4),
+      Feed("SPYB/USD", 0xCda6d5cE036AC0D6A387A377062EBd18Dd531177),
+      Feed("WDCB/USD", 0x583e282D4C914E1Faf47235769431899D7A5fB99)
     ];
 
     vm.startBroadcast(deployerPrivateKey);


### PR DESCRIPTION
## Summary
Add 10 new tokenized-equity Atlas Oracle push feeds (batch 4) to `script/oracle/deployAtlasOracleAdaptors.sol`.

| Symbol | Push feed address |
|--------|-------------------|
| CBRSB/USD | 0xB3FC5F9187EBE4640985E6607DDe7DE1C7067B04 |
| COINB/USD | 0x758aB25F2Db37AAE2CC09D5542B2C69b5fC70E61 |
| DRAMB/USD | 0x6eaed198cA7d86C7982C30CAC4dc1c28BE915744 |
| GLWB/USD | 0x60014fD4FcdB9778C771f510BC6F1abBa824c8f6 |
| GOOGLB/USD | 0x2FcEafD81a4dBDa2409B6fe5ce2afFe3cD46eDbC |
| NBISB/USD | 0x50f67D3CE440A98fFeC832726260ae03667fbE5E |
| QCOMB/USD | 0x22772c763Fc2B44eD59Da2BD309Fa8E4D00261f5 |
| SOXLB/USD | 0xbFC8C863B14f08e07e789328A424137E2B5933F4 |
| SPYB/USD | 0xCda6d5cE036AC0D6A387A377062EBd18Dd531177 |
| WDCB/USD | 0x583e282D4C914E1Faf47235769431899D7A5fB99 |

## Changes
- `Feed[5]` -> `Feed[10]`
- Batch 3 feeds (MSFTB/METAB/PLTRB/LITEB/QQQB) commented out as an on-chain record
- Added the 10 batch 4 feeds

## Verification
- On-chain `description()` checked for all 10 via `cast` against BSC mainnet.
- Each returns `"SingleFeed <SYMBOL>/USD"` (symbol portion matches the intended list), `decimals() == 18`, and `latestRoundData().answer > 0` (feed live).
- Note: the on-chain description carries a `"SingleFeed "` prefix. `AtlasOracleAdaptor.description()` is a pure passthrough and ResilientOracle maps by token address, so this is cosmetic and does not affect deployment.
- `forge build`: Compiler run successful (only lint notes, no errors).