### PR TITLE
feat(emergencySwitchHub): add PausableMock and deploy script

### DIFF
--- a/script/DeployPausableMock.s.sol
+++ b/script/DeployPausableMock.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import { Script } from "forge-std/Script.sol";
+import { PausableMock } from "../src/emergencySwitchHub/PausableMock.sol";
+
+contract DeployPausableMockScript is Script {
+  /**
+   * @dev Run the script
+   * sepolia:
+   * NAME=Moolah EMERGENCY_SWITCH_HUB=0x... \
+   *   forge script script/DeployPausableMock.s.sol --rpc-url <sepolia-rpc> --etherscan-api-key <etherscan-api-key> --broadcast --verify -vvv
+   */
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: %s", deployer);
+
+    string memory name = vm.envOr("NAME", string("PausableMock"));
+    console.log("Name: %s", name);
+    address emergencySwitchHub = vm.envAddress("EMERGENCY_SWITCH_HUB");
+    console.log("EmergencySwitchHub: %s", emergencySwitchHub);
+
+    vm.startBroadcast(deployerPrivateKey);
+    PausableMock mock = new PausableMock(name, emergencySwitchHub);
+    vm.stopBroadcast();
+
+    console.log("PausableMock address: %s", address(mock));
+  }
+}

--- a/src/emergencySwitchHub/PausableMock.sol
+++ b/src/emergencySwitchHub/PausableMock.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
+
+/**
+ * @title PausableMock
+ * @author Lista
+ * @dev Mock pausable contract used to exercise the EmergencySwitchHub on testnet.
+ *      It mirrors the access pattern of the real core contracts (Moolah,
+ *      StableSwapPool, XAUTStaking, ...): only the EmergencySwitchHub is allowed
+ *      to pause / unpause. The on-chain `name` lets each mock stand in for a
+ *      specific core contract when filling the deployment tables.
+ */
+contract PausableMock is Pausable {
+  /// @dev human readable name of the core contract this mock represents
+  string public name;
+  /// @dev the EmergencySwitchHub allowed to pause / unpause this contract
+  address public emergencySwitchHub;
+
+  modifier onlyEmergencySwitchHub() {
+    require(msg.sender == emergencySwitchHub, "PausableMock/not-EmergencySwitchHub");
+    _;
+  }
+
+  constructor(string memory _name, address _emergencySwitchHub) {
+    name = _name;
+    emergencySwitchHub = _emergencySwitchHub;
+  }
+
+  function pause() external onlyEmergencySwitchHub {
+    _pause();
+  }
+
+  function unpause() external onlyEmergencySwitchHub {
+    _unpause();
+  }
+}


### PR DESCRIPTION
## Summary

- Add `PausableMock` contract under `src/emergencySwitchHub/` — a mock pausable core contract for exercising `EmergencySwitchHub` on testnet. Only the `EmergencySwitchHub` may `pause()` / `unpause()`; the on-chain `name` lets each mock stand in for a specific core contract (Moolah, StableSwapPool, XAUTStaking, ...).
- Add `script/DeployPausableMock.s.sol` — plain constructor deploy with configurable `NAME` (default `PausableMock`) and `EMERGENCY_SWITCH_HUB` env vars.

## Test

`forge build` passes (remaining output is repo-wide lint style notes on other files).