### PR TITLE
feat(surfin): Surfin Credit Fund — FlexEarnPool, LockedEarnPool, InterestDistributor & SurfinAdapter

### DIFF
--- a/script/surfin/deploy_surfin_bsc.s.sol
+++ b/script/surfin/deploy_surfin_bsc.s.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import "../../src/surfin/FlexEarnPool.sol";
+import "../../src/surfin/LockedEarnPool.sol";
+import "../../src/surfin/SurfinAdapter.sol";
+import "../../src/surfin/InterestDistributor.sol";
+
+/**
+ * @title DeploySurfinBsc
+ * @notice BSC mainnet deploy of the Surfin Credit Fund stack: FlexEarnPool +
+ *         LockedEarnPool sharing one SurfinAdapter, plus the cumulative Merkle
+ *         InterestDistributor.
+ *
+ *         Role convention mirrors deploy_lisaster_rewards_v2_bsc / slisXAUE mainnet:
+ *           - DEFAULT_ADMIN / MANAGER stay on the deployer for post-deploy verification,
+ *             then rotate to TimeLock / multisig via transfer_surfin_roles.s.sol.
+ *           - PAUSER / BOT are pre-wired to their lista production holders here.
+ *
+ *         The pool <-> adapter dependency is circular: pools are initialized with the
+ *         deployer as a placeholder adapter (init stays atomic, no front-run window),
+ *         then rewired to the real adapter via setAdapter (DEFAULT_ADMIN-gated).
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=<key> BSCSCAN_API_KEY=<key> \
+ *     forge script script/surfin/deploy_surfin_bsc.s.sol:DeploySurfinBsc \
+ *     --rpc-url bsc --broadcast --verify -vvvv
+ */
+contract DeploySurfinBsc is Script {
+  /* ----- BSC mainnet externals ----- */
+  address constant USDT = 0x55d398326f99059fF775485246999027B3197955; // 18 decimals
+
+  /* ----- Surfin receiving wallet (off-chain custody/multisig) ----- */
+  // TODO: replace with the real Surfin receiving multisig before mainnet deploy.
+  address constant SURFIN_WALLET = 0x000000000000000000000000000000000000dEaD;
+
+  /* ----- Final role holders pre-wired at deploy (lista production) ----- */
+  address constant PAUSER_ADDR = 0xEEfebb1546d88EA0909435DF6f615084DD3c5Bd8;
+  address constant BOT_ADDR = 0x91fC4BA20685339781888eCA3E9E1c12d40F0e13;
+  address constant FEE_RECEIVER = 0x09702Ea135d9D707DD51f530864f2B9220aAD87B;
+
+  /* ----- Launch params (tune before mainnet; all MANAGER-adjustable later) ----- */
+  uint256 constant FLOOR_RATE = 3e16; // 3% hard floor (= contract default)
+  uint256 constant PENALTY_RATE = 0.008 ether; // 0.8% early-redeem penalty (= contract default)
+  uint256 constant MIN_DEPOSIT = 50e18; // 50 USDT (18-dec)
+  uint256 constant MIN_WITHDRAW = 50e18; // 50 USDT (18-dec); a sub-min request must drain the balance
+  uint256 constant FLEX_DAILY_LIMIT = 200_000e18; // 200k per-address/day flex withdraw cap
+  uint256 constant LOCKED_DAILY_LIMIT = 200_000e18; // 200k per-address/day locked early-redeem cap
+
+  /* ----- LP metadata ----- */
+  string constant FLEX_NAME = "Surfin Flex USDT";
+  string constant FLEX_SYMBOL = "sfUSDT";
+  string constant LOCKED_NAME = "Surfin Locked USDT";
+  string constant LOCKED_SYMBOL = "slUSDT";
+
+  function run() public {
+    require(block.chainid == 56, "expect BSC mainnet (chainId 56)");
+
+    uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPk);
+
+    // admin / manager: deployer holds both TEMPORARILY, handed over in transfer_surfin_roles.
+    address admin = deployer;
+    address manager = deployer;
+
+    console.log("Chain ID:  ", block.chainid);
+    console.log("Deployer:  ", deployer);
+    console.log("USDT:      ", USDT);
+
+    vm.startBroadcast(deployerPk);
+
+    // 1. FlexEarnPool + LockedEarnPool proxies (adapter placeholder = deployer).
+    //    Impl is inlined into the proxy constructor to keep run()'s stack shallow.
+    address flexProxy = address(
+      new ERC1967Proxy(
+        address(new FlexEarnPool()),
+        abi.encodeCall(
+          FlexEarnPool.initialize,
+          (admin, manager, PAUSER_ADDR, BOT_ADDR, USDT, deployer, FLEX_NAME, FLEX_SYMBOL)
+        )
+      )
+    );
+    address lockedProxy = address(
+      new ERC1967Proxy(
+        address(new LockedEarnPool()),
+        abi.encodeCall(
+          LockedEarnPool.initialize,
+          (admin, manager, PAUSER_ADDR, BOT_ADDR, USDT, deployer, LOCKED_NAME, LOCKED_SYMBOL)
+        )
+      )
+    );
+
+    // 2. SurfinAdapter proxy (real pool addresses + Surfin receiving wallet).
+    address adapterProxy = address(
+      new ERC1967Proxy(
+        address(new SurfinAdapter(USDT)),
+        abi.encodeCall(
+          SurfinAdapter.initialize,
+          (admin, manager, PAUSER_ADDR, BOT_ADDR, flexProxy, lockedProxy, SURFIN_WALLET)
+        )
+      )
+    );
+
+    // 3. InterestDistributor proxy (funder = adapter, the only caller of notifyReward).
+    //    NB init order: admin, manager, bot, pauser, funder, token.
+    address distributorProxy = address(
+      new ERC1967Proxy(
+        address(new InterestDistributor()),
+        abi.encodeCall(InterestDistributor.initialize, (admin, manager, BOT_ADDR, PAUSER_ADDR, adapterProxy, USDT))
+      )
+    );
+
+    // 4. rewire the real adapter into the pools (DEFAULT_ADMIN-gated, deployer holds it).
+    FlexEarnPool(flexProxy).setAdapter(adapterProxy);
+    LockedEarnPool(lockedProxy).setAdapter(adapterProxy);
+
+    // 5. adapter wiring + launch config (all MANAGER-gated, deployer holds MANAGER).
+    _configure(flexProxy, lockedProxy, adapterProxy, distributorProxy);
+
+    vm.stopBroadcast();
+
+    _verify(flexProxy, lockedProxy, adapterProxy, distributorProxy);
+    _log(flexProxy, lockedProxy, adapterProxy, distributorProxy, deployer);
+  }
+
+  /// @dev adapter interest wiring + fee/floor/penalty/limit config. Split out of run()
+  ///      to keep the stack shallow. Every setter is MANAGER-gated.
+  function _configure(address flexProxy, address lockedProxy, address adapterProxy, address distributorProxy) internal {
+    SurfinAdapter adapter = SurfinAdapter(adapterProxy);
+    adapter.setInterestDistributor(distributorProxy);
+    adapter.setFeeReceiver(FEE_RECEIVER);
+    adapter.setFloorRate(FLOOR_RATE);
+
+    LockedEarnPool(lockedProxy).setPenaltyRate(PENALTY_RATE);
+
+    if (MIN_DEPOSIT > 0) {
+      FlexEarnPool(flexProxy).setMinDeposit(MIN_DEPOSIT);
+      LockedEarnPool(lockedProxy).setMinDeposit(MIN_DEPOSIT);
+    }
+    if (MIN_WITHDRAW > 0) {
+      FlexEarnPool(flexProxy).setMinWithdraw(MIN_WITHDRAW);
+      LockedEarnPool(lockedProxy).setMinWithdraw(MIN_WITHDRAW);
+    }
+    if (FLEX_DAILY_LIMIT > 0) FlexEarnPool(flexProxy).setDailyLimit(FLEX_DAILY_LIMIT);
+    if (LOCKED_DAILY_LIMIT > 0) LockedEarnPool(lockedProxy).setDailyLimit(LOCKED_DAILY_LIMIT);
+  }
+
+  /// @dev post-deploy sanity assertions on critical wiring.
+  function _verify(
+    address flexProxy,
+    address lockedProxy,
+    address adapterProxy,
+    address distributorProxy
+  ) internal view {
+    SurfinAdapter adapter = SurfinAdapter(adapterProxy);
+    require(adapter.flexPool() == flexProxy, "adapter.flexPool mismatch");
+    require(adapter.lockedPool() == lockedProxy, "adapter.lockedPool mismatch");
+    require(adapter.interestDistributor() == distributorProxy, "adapter.interestDistributor mismatch");
+    require(adapter.surfinWallet() == SURFIN_WALLET, "adapter.surfinWallet mismatch");
+    require(FlexEarnPool(flexProxy).adapter() == adapterProxy, "flex.adapter mismatch");
+    require(LockedEarnPool(lockedProxy).adapter() == adapterProxy, "locked.adapter mismatch");
+    require(InterestDistributor(distributorProxy).token() == USDT, "distributor.token mismatch");
+  }
+
+  function _log(
+    address flexProxy,
+    address lockedProxy,
+    address adapterProxy,
+    address distributorProxy,
+    address deployer
+  ) internal pure {
+    console.log("==================================================");
+    console.log("Surfin Credit Fund deployed on BSC mainnet");
+    console.log("==================================================");
+    console.log("FlexEarnPool proxy:       ", flexProxy);
+    console.log("LockedEarnPool proxy:     ", lockedProxy);
+    console.log("SurfinAdapter proxy:      ", adapterProxy);
+    console.log("InterestDistributor proxy:", distributorProxy);
+    console.log("--------------------------------------------------");
+    console.log("admin/manager (deployer, rotate via transfer script):", deployer);
+    console.log("pauser:", PAUSER_ADDR);
+    console.log("bot:   ", BOT_ADDR);
+    console.log("--------------------------------------------------");
+    console.log("Next (runbook): 1) replace SURFIN_WALLET / FEE_RECEIVER placeholders;");
+    console.log("                2) fund/enable first locked cohort via setCohort (BOT);");
+    console.log("                3) transfer_surfin_roles.s.sol (admin->TimeLock, manager->multisig).");
+    console.log("==================================================");
+  }
+}

--- a/script/surfin/deploy_surfin_bsc.s.sol
+++ b/script/surfin/deploy_surfin_bsc.s.sol
@@ -58,6 +58,7 @@ contract DeploySurfinBsc is Script {
 
   function run() public {
     require(block.chainid == 56, "expect BSC mainnet (chainId 56)");
+    require(SURFIN_WALLET != 0x000000000000000000000000000000000000dEaD, "replace SURFIN_WALLET placeholder");
 
     uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
     address deployer = vm.addr(deployerPk);

--- a/script/surfin/deploy_surfin_eth.s.sol
+++ b/script/surfin/deploy_surfin_eth.s.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import "../../src/surfin/FlexEarnPool.sol";
+import "../../src/surfin/LockedEarnPool.sol";
+import "../../src/surfin/SurfinAdapter.sol";
+import "../../src/surfin/InterestDistributor.sol";
+
+/**
+ * @title DeploySurfinEth
+ * @notice Ethereum mainnet deploy of the Surfin Credit Fund stack: FlexEarnPool +
+ *         LockedEarnPool sharing one SurfinAdapter, plus the cumulative Merkle
+ *         InterestDistributor.
+ *
+ *         Identical wiring to deploy_surfin_bsc; the ONLY differences are the ETH
+ *         externals and USDT's 6-decimal precision (BSC USDT is 18-dec). The 1:1 LP
+ *         auto-follows asset.decimals(), and floor/penalty/fee are 1e18 rates, so
+ *         only absolute-amount params (MIN_DEPOSIT / daily limits) are scaled to 6-dec.
+ *
+ *         Role convention: DEFAULT_ADMIN / MANAGER stay on the deployer for post-deploy
+ *         verification, then rotate via transfer_surfin_roles.s.sol; PAUSER / BOT are
+ *         pre-wired to their lista production holders here.
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=<key> ETHERSCAN_API_KEY=<key> \
+ *     forge script script/surfin/deploy_surfin_eth.s.sol:DeploySurfinEth \
+ *     --rpc-url eth --broadcast --verify -vvvv
+ */
+contract DeploySurfinEth is Script {
+  /* ----- Ethereum mainnet externals ----- */
+  address constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7; // 6 decimals
+
+  /* ----- Surfin receiving wallet (off-chain custody/multisig) ----- */
+  // TODO: replace with the real Surfin receiving multisig before mainnet deploy.
+  address constant SURFIN_WALLET = 0x000000000000000000000000000000000000dEaD;
+
+  /* ----- Final role holders pre-wired at deploy (lista production) ----- */
+  address constant PAUSER_ADDR = 0xEEfebb1546d88EA0909435DF6f615084DD3c5Bd8;
+  address constant BOT_ADDR = 0x91fC4BA20685339781888eCA3E9E1c12d40F0e13;
+  address constant FEE_RECEIVER = 0x09702Ea135d9D707DD51f530864f2B9220aAD87B;
+
+  /* ----- Launch params (tune before mainnet; all MANAGER-adjustable later) ----- */
+  uint256 constant FLOOR_RATE = 3e16; // 3% hard floor (= contract default; rate, precision-agnostic)
+  uint256 constant PENALTY_RATE = 0.008 ether; // 0.8% early-redeem penalty (= contract default; rate)
+  uint256 constant MIN_DEPOSIT = 50e6; // 50 USDT (6-dec on ETH)
+  uint256 constant MIN_WITHDRAW = 50e6; // 50 USDT (6-dec); a sub-min request must drain the balance
+  uint256 constant FLEX_DAILY_LIMIT = 200_000e6; // 200k per-address/day flex withdraw cap (6-dec)
+  uint256 constant LOCKED_DAILY_LIMIT = 200_000e6; // 200k per-address/day locked early-redeem cap (6-dec)
+
+  /* ----- LP metadata ----- */
+  string constant FLEX_NAME = "Surfin Flex USDT";
+  string constant FLEX_SYMBOL = "sfUSDT";
+  string constant LOCKED_NAME = "Surfin Locked USDT";
+  string constant LOCKED_SYMBOL = "slUSDT";
+
+  function run() public {
+    require(block.chainid == 1, "expect ETH mainnet (chainId 1)");
+
+    uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPk);
+
+    // admin / manager: deployer holds both TEMPORARILY, handed over in transfer_surfin_roles.
+    address admin = deployer;
+    address manager = deployer;
+
+    console.log("Chain ID:  ", block.chainid);
+    console.log("Deployer:  ", deployer);
+    console.log("USDT:      ", USDT);
+
+    vm.startBroadcast(deployerPk);
+
+    // 1. FlexEarnPool + LockedEarnPool proxies (adapter placeholder = deployer).
+    //    Impl is inlined into the proxy constructor to keep run()'s stack shallow.
+    address flexProxy = address(
+      new ERC1967Proxy(
+        address(new FlexEarnPool()),
+        abi.encodeCall(
+          FlexEarnPool.initialize,
+          (admin, manager, PAUSER_ADDR, BOT_ADDR, USDT, deployer, FLEX_NAME, FLEX_SYMBOL)
+        )
+      )
+    );
+    address lockedProxy = address(
+      new ERC1967Proxy(
+        address(new LockedEarnPool()),
+        abi.encodeCall(
+          LockedEarnPool.initialize,
+          (admin, manager, PAUSER_ADDR, BOT_ADDR, USDT, deployer, LOCKED_NAME, LOCKED_SYMBOL)
+        )
+      )
+    );
+
+    // 2. SurfinAdapter proxy (real pool addresses + Surfin receiving wallet).
+    address adapterProxy = address(
+      new ERC1967Proxy(
+        address(new SurfinAdapter(USDT)),
+        abi.encodeCall(
+          SurfinAdapter.initialize,
+          (admin, manager, PAUSER_ADDR, BOT_ADDR, flexProxy, lockedProxy, SURFIN_WALLET)
+        )
+      )
+    );
+
+    // 3. InterestDistributor proxy (funder = adapter, the only caller of notifyReward).
+    //    NB init order: admin, manager, bot, pauser, funder, token.
+    address distributorProxy = address(
+      new ERC1967Proxy(
+        address(new InterestDistributor()),
+        abi.encodeCall(InterestDistributor.initialize, (admin, manager, BOT_ADDR, PAUSER_ADDR, adapterProxy, USDT))
+      )
+    );
+
+    // 4. rewire the real adapter into the pools (DEFAULT_ADMIN-gated, deployer holds it).
+    FlexEarnPool(flexProxy).setAdapter(adapterProxy);
+    LockedEarnPool(lockedProxy).setAdapter(adapterProxy);
+
+    // 5. adapter wiring + launch config (all MANAGER-gated, deployer holds MANAGER).
+    _configure(flexProxy, lockedProxy, adapterProxy, distributorProxy);
+
+    vm.stopBroadcast();
+
+    _verify(flexProxy, lockedProxy, adapterProxy, distributorProxy);
+    _log(flexProxy, lockedProxy, adapterProxy, distributorProxy, deployer);
+  }
+
+  /// @dev adapter interest wiring + fee/floor/penalty/limit config. Split out of run()
+  ///      to keep the stack shallow. Every setter is MANAGER-gated.
+  function _configure(address flexProxy, address lockedProxy, address adapterProxy, address distributorProxy) internal {
+    SurfinAdapter adapter = SurfinAdapter(adapterProxy);
+    adapter.setInterestDistributor(distributorProxy);
+    adapter.setFeeReceiver(FEE_RECEIVER);
+    adapter.setFloorRate(FLOOR_RATE);
+
+    LockedEarnPool(lockedProxy).setPenaltyRate(PENALTY_RATE);
+
+    if (MIN_DEPOSIT > 0) {
+      FlexEarnPool(flexProxy).setMinDeposit(MIN_DEPOSIT);
+      LockedEarnPool(lockedProxy).setMinDeposit(MIN_DEPOSIT);
+    }
+    if (MIN_WITHDRAW > 0) {
+      FlexEarnPool(flexProxy).setMinWithdraw(MIN_WITHDRAW);
+      LockedEarnPool(lockedProxy).setMinWithdraw(MIN_WITHDRAW);
+    }
+    if (FLEX_DAILY_LIMIT > 0) FlexEarnPool(flexProxy).setDailyLimit(FLEX_DAILY_LIMIT);
+    if (LOCKED_DAILY_LIMIT > 0) LockedEarnPool(lockedProxy).setDailyLimit(LOCKED_DAILY_LIMIT);
+  }
+
+  /// @dev post-deploy sanity assertions on critical wiring.
+  function _verify(
+    address flexProxy,
+    address lockedProxy,
+    address adapterProxy,
+    address distributorProxy
+  ) internal view {
+    SurfinAdapter adapter = SurfinAdapter(adapterProxy);
+    require(adapter.flexPool() == flexProxy, "adapter.flexPool mismatch");
+    require(adapter.lockedPool() == lockedProxy, "adapter.lockedPool mismatch");
+    require(adapter.interestDistributor() == distributorProxy, "adapter.interestDistributor mismatch");
+    require(adapter.surfinWallet() == SURFIN_WALLET, "adapter.surfinWallet mismatch");
+    require(FlexEarnPool(flexProxy).adapter() == adapterProxy, "flex.adapter mismatch");
+    require(LockedEarnPool(lockedProxy).adapter() == adapterProxy, "locked.adapter mismatch");
+    require(InterestDistributor(distributorProxy).token() == USDT, "distributor.token mismatch");
+  }
+
+  function _log(
+    address flexProxy,
+    address lockedProxy,
+    address adapterProxy,
+    address distributorProxy,
+    address deployer
+  ) internal pure {
+    console.log("==================================================");
+    console.log("Surfin Credit Fund deployed on Ethereum mainnet");
+    console.log("==================================================");
+    console.log("FlexEarnPool proxy:       ", flexProxy);
+    console.log("LockedEarnPool proxy:     ", lockedProxy);
+    console.log("SurfinAdapter proxy:      ", adapterProxy);
+    console.log("InterestDistributor proxy:", distributorProxy);
+    console.log("--------------------------------------------------");
+    console.log("admin/manager (deployer, rotate via transfer script):", deployer);
+    console.log("pauser:", PAUSER_ADDR);
+    console.log("bot:   ", BOT_ADDR);
+    console.log("--------------------------------------------------");
+    console.log("Next (runbook): 1) replace SURFIN_WALLET / FEE_RECEIVER placeholders;");
+    console.log("                2) fund/enable first locked cohort via setCohort (BOT);");
+    console.log("                3) transfer_surfin_roles.s.sol (admin->TimeLock, manager->multisig).");
+    console.log("==================================================");
+  }
+}

--- a/script/surfin/deploy_surfin_eth.s.sol
+++ b/script/surfin/deploy_surfin_eth.s.sol
@@ -58,6 +58,7 @@ contract DeploySurfinEth is Script {
 
   function run() public {
     require(block.chainid == 1, "expect ETH mainnet (chainId 1)");
+    require(SURFIN_WALLET != 0x000000000000000000000000000000000000dEaD, "replace SURFIN_WALLET placeholder");
 
     uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
     address deployer = vm.addr(deployerPk);

--- a/script/surfin/deploy_surfin_impl.s.sol
+++ b/script/surfin/deploy_surfin_impl.s.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+
+import "../../src/surfin/FlexEarnPool.sol";
+import "../../src/surfin/LockedEarnPool.sol";
+import "../../src/surfin/SurfinAdapter.sol";
+import "../../src/surfin/InterestDistributor.sol";
+
+/**
+ * @title DeploySurfinImpl
+ * @notice Deploys fresh UUPS implementations for the Surfin stack (upgrade prep).
+ *         Only SurfinAdapter takes a constructor arg (the immutable asset/USDT), so
+ *         the correct USDT is selected per chain. FlexEarnPool / LockedEarnPool /
+ *         InterestDistributor have no constructor args.
+ *
+ *         This script ONLY deploys implementations; the upgrade itself is executed by
+ *         the DEFAULT_ADMIN (TimeLock) on each proxy:
+ *             proxy.upgradeToAndCall(newImpl, "")
+ *         Deploy only the impls you actually intend to upgrade — comment out the rest.
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=<key> BSCSCAN_API_KEY=<key> \
+ *     forge script script/surfin/deploy_surfin_impl.s.sol:DeploySurfinImpl \
+ *     --rpc-url <bsc|eth|bsc_testnet|sepolia> --broadcast --verify -vvvv
+ */
+contract DeploySurfinImpl is Script {
+  address constant BSC_USDT = 0x55d398326f99059fF775485246999027B3197955; // 18-dec
+  address constant ETH_USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7; // 6-dec
+  // TODO: set the BSC-testnet USDT (the 18-dec MockERC20 from deploy_surfin_testnet) for chainId 97.
+  address constant BSC_TESTNET_USDT = address(0);
+  // TODO: set the Sepolia USDT (the 6-dec mock from deploy_surfin_sepolia) for chainId 11155111.
+  address constant SEPOLIA_USDT = address(0);
+
+  function run() public {
+    address usdt = _usdt();
+
+    uint256 pk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    console.log("Chain ID:", block.chainid);
+    console.log("USDT (adapter ctor):", usdt);
+
+    vm.startBroadcast(pk);
+    address flexImpl = address(new FlexEarnPool());
+    address lockedImpl = address(new LockedEarnPool());
+    address adapterImpl = address(new SurfinAdapter(usdt));
+    address distributorImpl = address(new InterestDistributor());
+    vm.stopBroadcast();
+
+    console.log("---- New implementations ----");
+    console.log("FlexEarnPool impl:       ", flexImpl);
+    console.log("LockedEarnPool impl:     ", lockedImpl);
+    console.log("SurfinAdapter impl:      ", adapterImpl);
+    console.log("InterestDistributor impl:", distributorImpl);
+    console.log('Upgrade via DEFAULT_ADMIN (TimeLock): proxy.upgradeToAndCall(newImpl, "")');
+  }
+
+  /// @dev per-chain USDT for the SurfinAdapter constructor.
+  function _usdt() internal view returns (address) {
+    if (block.chainid == 56) return BSC_USDT;
+    if (block.chainid == 1) return ETH_USDT;
+    if (block.chainid == 97) {
+      require(BSC_TESTNET_USDT != address(0), "set BSC_TESTNET_USDT for the adapter impl");
+      return BSC_TESTNET_USDT;
+    }
+    if (block.chainid == 11155111) {
+      require(SEPOLIA_USDT != address(0), "set SEPOLIA_USDT for the adapter impl");
+      return SEPOLIA_USDT;
+    }
+    revert("unsupported chain");
+  }
+}

--- a/script/surfin/deploy_surfin_sepolia.s.sol
+++ b/script/surfin/deploy_surfin_sepolia.s.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import "../../src/surfin/FlexEarnPool.sol";
+import "../../src/surfin/LockedEarnPool.sol";
+import "../../src/surfin/SurfinAdapter.sol";
+import "../../src/surfin/InterestDistributor.sol";
+import "../../src/mock/MockERC20.sol";
+
+/**
+ * @dev 6-decimal test USDT. MockERC20 is fixed at 18 decimals, but real USDT on ETH
+ *      mainnet is 6-dec, so Sepolia deploys this override to exercise the ETH precision
+ *      path (absolute-amount params like MIN_DEPOSIT are 6-dec here) before the real
+ *      deploy_surfin_eth run.
+ */
+contract MockUSDT6 is MockERC20 {
+  constructor() MockERC20("Test USDT", "USDT") {}
+
+  function decimals() public pure override returns (uint8) {
+    return 6;
+  }
+}
+
+/**
+ * @title DeploySurfinSepolia
+ * @notice Sepolia (ETH testnet) deploy of the full Surfin Credit Fund stack. Mirrors
+ *         deploy_surfin_testnet (self-contained, all roles = deployer, shortened
+ *         distributor time-lock), the ONLY difference being a 6-DECIMAL mock USDT so
+ *         the ETH mainnet precision path is validated before deploy_surfin_eth.
+ *
+ *         ALL roles (admin/manager/pauser/bot) default to the deployer; the distributor
+ *         time-lock is shortened to WAITING_PERIOD for fast root-publish testing (do NOT
+ *         ship that value to mainnet).
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=<key> ETHERSCAN_API_KEY=<key> \
+ *     forge script script/surfin/deploy_surfin_sepolia.s.sol:DeploySurfinSepolia \
+ *     --rpc-url sepolia --broadcast --verify -vvvv
+ */
+contract DeploySurfinSepolia is Script {
+  /* ----- Test USDT: address(0) => deploy a fresh 6-dec mock; else reuse this token ----- */
+  address constant TEST_USDT_OVERRIDE = address(0);
+
+  /* ----- Launch params (6-dec, testnet-friendly) ----- */
+  uint256 constant FLOOR_RATE = 3e16; // 3% hard floor (rate, precision-agnostic)
+  uint256 constant PENALTY_RATE = 0.008 ether; // 0.8% early-redeem penalty (rate)
+  uint256 constant MIN_DEPOSIT = 50e6; // 50 test-USDT (6-dec mock)
+  uint256 constant MIN_WITHDRAW = 50e6; // 50 test-USDT (6-dec); a sub-min request must drain the balance
+  uint256 constant DAILY_LIMIT = 200_000e6; // 200k per-address/day withdraw cap (6-dec)
+  uint256 constant WAITING_PERIOD = 5 minutes; // shortened distributor time-lock (testnet only)
+
+  /* ----- LP metadata ----- */
+  string constant FLEX_NAME = "Surfin Flex USDT";
+  string constant FLEX_SYMBOL = "sfUSDT";
+  string constant LOCKED_NAME = "Surfin Locked USDT";
+  string constant LOCKED_SYMBOL = "slUSDT";
+
+  function run() public {
+    require(block.chainid == 11155111, "expect Sepolia (chainId 11155111)");
+
+    uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPk);
+
+    // All roles default to the deployer on testnet.
+    address admin = deployer;
+
+    console.log("Chain ID:", block.chainid);
+    console.log("Deployer:", deployer);
+
+    vm.startBroadcast(deployerPk);
+
+    // 0. test USDT (6-dec mock unless an override is provided).
+    address usdt = TEST_USDT_OVERRIDE == address(0) ? address(new MockUSDT6()) : TEST_USDT_OVERRIDE;
+
+    // 1. FlexEarnPool + LockedEarnPool proxies (adapter placeholder = deployer).
+    address flexProxy = address(
+      new ERC1967Proxy(
+        address(new FlexEarnPool()),
+        abi.encodeCall(FlexEarnPool.initialize, (admin, admin, admin, admin, usdt, deployer, FLEX_NAME, FLEX_SYMBOL))
+      )
+    );
+    address lockedProxy = address(
+      new ERC1967Proxy(
+        address(new LockedEarnPool()),
+        abi.encodeCall(
+          LockedEarnPool.initialize,
+          (admin, admin, admin, admin, usdt, deployer, LOCKED_NAME, LOCKED_SYMBOL)
+        )
+      )
+    );
+
+    // 2. SurfinAdapter proxy (surfinWallet = deployer on testnet).
+    address adapterProxy = address(
+      new ERC1967Proxy(
+        address(new SurfinAdapter(usdt)),
+        abi.encodeCall(SurfinAdapter.initialize, (admin, admin, admin, admin, flexProxy, lockedProxy, deployer))
+      )
+    );
+
+    // 3. InterestDistributor proxy (funder = adapter). Init order: admin, manager, bot, pauser, funder, token.
+    address distributorProxy = address(
+      new ERC1967Proxy(
+        address(new InterestDistributor()),
+        abi.encodeCall(InterestDistributor.initialize, (admin, admin, admin, admin, adapterProxy, usdt))
+      )
+    );
+
+    // 4. rewire the real adapter into the pools.
+    FlexEarnPool(flexProxy).setAdapter(adapterProxy);
+    LockedEarnPool(lockedProxy).setAdapter(adapterProxy);
+
+    // 5. adapter wiring + launch config + shortened distributor time-lock.
+    _configure(flexProxy, lockedProxy, adapterProxy, distributorProxy, deployer);
+
+    vm.stopBroadcast();
+
+    // 6. sanity: the 6-dec asset must propagate through the 1:1 LP, so the ETH mainnet
+    //    precision path is genuinely exercised on Sepolia.
+    require(FlexEarnPool(flexProxy).decimals() == 6, "flex LP decimals != 6");
+    require(LockedEarnPool(lockedProxy).decimals() == 6, "locked LP decimals != 6");
+
+    console.log("==================================================");
+    console.log("Surfin Credit Fund deployed on Sepolia (6-dec USDT)");
+    console.log("==================================================");
+    console.log("Test USDT (6-dec):        ", usdt);
+    console.log("FlexEarnPool proxy:       ", flexProxy);
+    console.log("LockedEarnPool proxy:     ", lockedProxy);
+    console.log("SurfinAdapter proxy:      ", adapterProxy);
+    console.log("InterestDistributor proxy:", distributorProxy);
+    console.log("all roles -> deployer:    ", deployer);
+    console.log("==================================================");
+  }
+
+  /// @dev testnet wiring: interest distributor, fee sink (= deployer), rates, min deposit,
+  ///      and the shortened distributor time-lock. All setters are MANAGER-gated (= deployer).
+  function _configure(
+    address flexProxy,
+    address lockedProxy,
+    address adapterProxy,
+    address distributorProxy,
+    address deployer
+  ) internal {
+    SurfinAdapter adapter = SurfinAdapter(adapterProxy);
+    adapter.setInterestDistributor(distributorProxy);
+    adapter.setFeeReceiver(deployer);
+    adapter.setFloorRate(FLOOR_RATE);
+
+    LockedEarnPool(lockedProxy).setPenaltyRate(PENALTY_RATE);
+    FlexEarnPool(flexProxy).setMinDeposit(MIN_DEPOSIT);
+    LockedEarnPool(lockedProxy).setMinDeposit(MIN_DEPOSIT);
+    FlexEarnPool(flexProxy).setMinWithdraw(MIN_WITHDRAW);
+    LockedEarnPool(lockedProxy).setMinWithdraw(MIN_WITHDRAW);
+    FlexEarnPool(flexProxy).setDailyLimit(DAILY_LIMIT);
+    LockedEarnPool(lockedProxy).setDailyLimit(DAILY_LIMIT);
+
+    // fast root-publish iteration on testnet only.
+    InterestDistributor(distributorProxy).changeWaitingPeriod(WAITING_PERIOD);
+  }
+}

--- a/script/surfin/deploy_surfin_testnet.s.sol
+++ b/script/surfin/deploy_surfin_testnet.s.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import "../../src/surfin/FlexEarnPool.sol";
+import "../../src/surfin/LockedEarnPool.sol";
+import "../../src/surfin/SurfinAdapter.sol";
+import "../../src/surfin/InterestDistributor.sol";
+import "../../src/mock/MockERC20.sol";
+
+/**
+ * @title DeploySurfinTestnet
+ * @notice BSC testnet deploy of the full Surfin Credit Fund stack for iteration.
+ *
+ *         Differences from the mainnet scripts:
+ *           - deploys a fresh MockERC20 (18-dec) as the test USDT so the stack is
+ *             self-contained; swap TEST_USDT_OVERRIDE for an existing testnet token
+ *             if you'd rather reuse one.
+ *           - ALL roles (admin/manager/pauser/bot) default to the deployer for easy
+ *             iteration; rotate later via grantRole if needed.
+ *           - the InterestDistributor time-lock is shortened to WAITING_PERIOD for
+ *             fast root-publish testing (do NOT ship this value to mainnet).
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=<key> BSCSCAN_API_KEY=<key> \
+ *     forge script script/surfin/deploy_surfin_testnet.s.sol:DeploySurfinTestnet \
+ *     --rpc-url bsc_testnet --broadcast --verify -vvvv
+ */
+contract DeploySurfinTestnet is Script {
+  /* ----- Test USDT: address(0) => deploy a fresh MockERC20; else reuse this token ----- */
+  address constant TEST_USDT_OVERRIDE = address(0);
+
+  /* ----- Launch params (testnet-friendly) ----- */
+  uint256 constant FLOOR_RATE = 3e16; // 3% hard floor
+  uint256 constant PENALTY_RATE = 0.008 ether; // 0.8% early-redeem penalty
+  uint256 constant MIN_DEPOSIT = 50e18; // 50 test-USDT (18-dec mock)
+  uint256 constant MIN_WITHDRAW = 50e18; // 50 test-USDT (18-dec); a sub-min request must drain the balance
+  uint256 constant DAILY_LIMIT = 200_000e18; // 200k per-address/day withdraw cap
+  uint256 constant WAITING_PERIOD = 5 minutes; // shortened distributor time-lock (testnet only)
+
+  /* ----- LP metadata ----- */
+  string constant FLEX_NAME = "Surfin Flex USDT";
+  string constant FLEX_SYMBOL = "sfUSDT";
+  string constant LOCKED_NAME = "Surfin Locked USDT";
+  string constant LOCKED_SYMBOL = "slUSDT";
+
+  function run() public {
+    require(block.chainid == 97, "expect BSC testnet (chainId 97)");
+
+    uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPk);
+
+    // All roles default to the deployer on testnet.
+    address admin = deployer;
+
+    console.log("Chain ID:", block.chainid);
+    console.log("Deployer:", deployer);
+
+    vm.startBroadcast(deployerPk);
+
+    // 0. test USDT (mock unless an override is provided).
+    address usdt = TEST_USDT_OVERRIDE == address(0) ? address(new MockERC20("Test USDT", "USDT")) : TEST_USDT_OVERRIDE;
+
+    // 1. FlexEarnPool + LockedEarnPool proxies (adapter placeholder = deployer).
+    address flexProxy = address(
+      new ERC1967Proxy(
+        address(new FlexEarnPool()),
+        abi.encodeCall(FlexEarnPool.initialize, (admin, admin, admin, admin, usdt, deployer, FLEX_NAME, FLEX_SYMBOL))
+      )
+    );
+    address lockedProxy = address(
+      new ERC1967Proxy(
+        address(new LockedEarnPool()),
+        abi.encodeCall(
+          LockedEarnPool.initialize,
+          (admin, admin, admin, admin, usdt, deployer, LOCKED_NAME, LOCKED_SYMBOL)
+        )
+      )
+    );
+
+    // 2. SurfinAdapter proxy (surfinWallet = deployer on testnet).
+    address adapterProxy = address(
+      new ERC1967Proxy(
+        address(new SurfinAdapter(usdt)),
+        abi.encodeCall(SurfinAdapter.initialize, (admin, admin, admin, admin, flexProxy, lockedProxy, deployer))
+      )
+    );
+
+    // 3. InterestDistributor proxy (funder = adapter). Init order: admin, manager, bot, pauser, funder, token.
+    address distributorProxy = address(
+      new ERC1967Proxy(
+        address(new InterestDistributor()),
+        abi.encodeCall(InterestDistributor.initialize, (admin, admin, admin, admin, adapterProxy, usdt))
+      )
+    );
+
+    // 4. rewire the real adapter into the pools.
+    FlexEarnPool(flexProxy).setAdapter(adapterProxy);
+    LockedEarnPool(lockedProxy).setAdapter(adapterProxy);
+
+    // 5. adapter wiring + launch config + shortened distributor time-lock.
+    _configure(flexProxy, lockedProxy, adapterProxy, distributorProxy, deployer);
+
+    vm.stopBroadcast();
+
+    console.log("==================================================");
+    console.log("Surfin Credit Fund deployed on BSC testnet");
+    console.log("==================================================");
+    console.log("Test USDT:                ", usdt);
+    console.log("FlexEarnPool proxy:       ", flexProxy);
+    console.log("LockedEarnPool proxy:     ", lockedProxy);
+    console.log("SurfinAdapter proxy:      ", adapterProxy);
+    console.log("InterestDistributor proxy:", distributorProxy);
+    console.log("all roles -> deployer:    ", deployer);
+    console.log("==================================================");
+  }
+
+  /// @dev testnet wiring: interest distributor, fee sink (= deployer), rates, min deposit,
+  ///      and the shortened distributor time-lock. All setters are MANAGER-gated (= deployer).
+  function _configure(
+    address flexProxy,
+    address lockedProxy,
+    address adapterProxy,
+    address distributorProxy,
+    address deployer
+  ) internal {
+    SurfinAdapter adapter = SurfinAdapter(adapterProxy);
+    adapter.setInterestDistributor(distributorProxy);
+    adapter.setFeeReceiver(deployer);
+    adapter.setFloorRate(FLOOR_RATE);
+
+    LockedEarnPool(lockedProxy).setPenaltyRate(PENALTY_RATE);
+    FlexEarnPool(flexProxy).setMinDeposit(MIN_DEPOSIT);
+    LockedEarnPool(lockedProxy).setMinDeposit(MIN_DEPOSIT);
+    FlexEarnPool(flexProxy).setMinWithdraw(MIN_WITHDRAW);
+    LockedEarnPool(lockedProxy).setMinWithdraw(MIN_WITHDRAW);
+    FlexEarnPool(flexProxy).setDailyLimit(DAILY_LIMIT);
+    LockedEarnPool(lockedProxy).setDailyLimit(DAILY_LIMIT);
+
+    // fast root-publish iteration on testnet only.
+    InterestDistributor(distributorProxy).changeWaitingPeriod(WAITING_PERIOD);
+  }
+}

--- a/script/surfin/transfer_surfin_roles.s.sol
+++ b/script/surfin/transfer_surfin_roles.s.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+
+/**
+ * @title TransferSurfinRoles
+ * @notice Hands Surfin governance from the deployer (temporary admin/manager) to
+ *         production custody on all four proxies (FlexEarnPool, LockedEarnPool,
+ *         SurfinAdapter, InterestDistributor):
+ *           - DEFAULT_ADMIN_ROLE -> ADMIN (TimeLock; upgrade authority)
+ *           - MANAGER            -> MANAGER_MULTISIG (Safe)
+ *           - then renounces the deployer's MANAGER + DEFAULT_ADMIN on each.
+ *         PAUSER / BOT (and the distributor's FUNDER = adapter) were set to their
+ *         final holders at deploy time and are left untouched.
+ *
+ * @dev Run AFTER deploy + first-cohort setup, signed by the current deployer/admin.
+ *      DEFAULT_ADMIN is renounced LAST per contract (the grants above need it). IRREVERSIBLE.
+ *
+ *      Chain-scoped: fill in the deployed proxy addresses AND the production custody
+ *      addresses for the chain you are rotating, then run with that chain's RPC.
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=<key> \
+ *     forge script script/surfin/transfer_surfin_roles.s.sol:TransferSurfinRoles \
+ *     --rpc-url <bsc|eth> --broadcast -vvvv
+ */
+contract TransferSurfinRoles is Script {
+  bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+
+  /* =========================== BSC mainnet (chainId 56) =========================== */
+  // TODO: fill in after deploy_surfin_bsc. Left as address(0) so the run() guard blocks an unset run.
+  address constant BSC_FLEX = address(0);
+  address constant BSC_LOCKED = address(0);
+  address constant BSC_ADAPTER = address(0);
+  address constant BSC_DISTRIBUTOR = address(0);
+  // TODO: BSC production custody (TimeLock + Safe).
+  address constant BSC_ADMIN = address(0);
+  address constant BSC_MANAGER_MULTISIG = address(0);
+
+  /* =========================== ETH mainnet (chainId 1) =========================== */
+  // TODO: fill in after deploy_surfin_eth. Left as address(0) so the run() guard blocks an unset run.
+  address constant ETH_FLEX = address(0);
+  address constant ETH_LOCKED = address(0);
+  address constant ETH_ADAPTER = address(0);
+  address constant ETH_DISTRIBUTOR = address(0);
+  // TODO: ETH production custody (TimeLock + Safe).
+  address constant ETH_ADMIN = address(0);
+  address constant ETH_MANAGER_MULTISIG = address(0);
+
+  function run() public {
+    uint256 pk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(pk);
+
+    (address flex, address locked, address adapter, address distributor, address admin, address multisig) = _resolve();
+
+    require(admin != address(0) && multisig != address(0), "custody unset");
+    require(
+      flex != address(0) && locked != address(0) && adapter != address(0) && distributor != address(0),
+      "proxy unset"
+    );
+
+    console.log("Chain ID:", block.chainid);
+    console.log("Deployer (renouncing):", deployer);
+    console.log("DEFAULT_ADMIN ->", admin);
+    console.log("MANAGER ->", multisig);
+
+    vm.startBroadcast(pk);
+    _rotate(flex, admin, multisig, deployer);
+    _rotate(locked, admin, multisig, deployer);
+    _rotate(adapter, admin, multisig, deployer);
+    _rotate(distributor, admin, multisig, deployer);
+    vm.stopBroadcast();
+
+    console.log("Done. Verify per proxy: DEFAULT_ADMIN==ADMIN & count==1; MANAGER==multisig; deployer holds nothing.");
+  }
+
+  /// @dev pick the deployed proxies + custody for the current chain.
+  function _resolve()
+    internal
+    view
+    returns (address flex, address locked, address adapter, address distributor, address admin, address multisig)
+  {
+    if (block.chainid == 56) {
+      return (BSC_FLEX, BSC_LOCKED, BSC_ADAPTER, BSC_DISTRIBUTOR, BSC_ADMIN, BSC_MANAGER_MULTISIG);
+    } else if (block.chainid == 1) {
+      return (ETH_FLEX, ETH_LOCKED, ETH_ADAPTER, ETH_DISTRIBUTOR, ETH_ADMIN, ETH_MANAGER_MULTISIG);
+    }
+    revert("unsupported chain");
+  }
+
+  /// @dev grant new custody, then renounce the deployer. DEFAULT_ADMIN renounced LAST.
+  function _rotate(address proxy, address timelock, address multisig, address deployer) internal {
+    IAccessControl ac = IAccessControl(proxy);
+    ac.grantRole(MANAGER, multisig);
+    ac.grantRole(DEFAULT_ADMIN_ROLE, timelock);
+    ac.renounceRole(MANAGER, deployer);
+    ac.renounceRole(DEFAULT_ADMIN_ROLE, deployer);
+  }
+}

--- a/src/surfin/CreditFundBase.sol
+++ b/src/surfin/CreditFundBase.sol
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title CreditFundBase
+ * @notice Shared base for the Surfin flex/locked earn pools.
+ *
+ * Design follows lista-new-contracts/src/rwa/RWAEarnPool.sol:
+ *  - deposits transfer funds straight to the adapter (pool keeps only accounting);
+ *  - withdrawals go through a daily batch queue that the adapter repays via
+ *    `finishWithdraw`, then users `claimWithdraw`;
+ *  - interest is booked separately from principal: principal is claimed as batch
+ *    withdrawals here, while interest is distributed off-pool via the cumulative
+ *    Merkle `InterestDistributor`.
+ *
+ * Principal bookkeeping differs between products (1:1 LP for flex, positions for
+ * locked) so `totalPrincipal` and the deposit/withdraw entrypoints are left to
+ * the child contract; everything shared lives here.
+ */
+abstract contract CreditFundBase is
+  UUPSUpgradeable,
+  AccessControlEnumerableUpgradeable,
+  PausableUpgradeable,
+  ReentrancyGuardUpgradeable
+{
+  using SafeERC20 for IERC20;
+
+  /* STRUCTS */
+  // batchId: batch the request belongs to
+  // withdrawTime: timestamp of the request
+  // amount: principal payout to release
+  // cohortId: source cohort for locked withdrawals (0 for flex, which has no cohorts)
+  struct WithdrawalRequest {
+    uint256 batchId;
+    uint256 withdrawTime;
+    uint256 amount;
+    uint256 cohortId;
+  }
+
+  /* VARIABLES */
+  // asset token address (USDT)
+  address public asset;
+  // adapter address (holds the funds, drives the pool)
+  address public adapter;
+  // pool display name / symbol
+  string public name;
+  string public symbol;
+
+  // user => withdrawal requests
+  mapping(address => WithdrawalRequest[]) internal userWithdrawalRequests;
+  // batch id => total withdraw amount in the batch
+  mapping(uint256 => uint256) public totalWithdrawAmountInBatch;
+  // amount received from adapter but not yet assigned to a confirmed batch
+  uint256 public withdrawQuota;
+  // current (open) batch id
+  uint256 public currentBatchId;
+  // last confirmed batch id
+  uint256 public confirmedBatchId;
+  // last epoch day a batch was opened
+  uint256 public lastDay;
+  // total principal requested for withdraw but not yet claimed
+  uint256 public totalPendingWithdraw;
+
+  // per-address per-day submitted withdraw amount, 0 disables the limit
+  uint256 public dailyLimit;
+  // epoch day => user => submitted amount
+  mapping(uint256 => mapping(address => uint256)) public dailySubmitted;
+
+  // minimum deposit amount, in asset units
+  uint256 public minDeposit;
+  // minimum withdraw amount, in asset units; a below-minimum request is only allowed
+  // when it drains the caller's whole balance/position (dust exit). 0 disables it.
+  uint256 public minWithdraw;
+  // when true, blocks new deposits and locked early redemptions (wind-down / stress
+  // mode); normal & matured withdrawals and claims stay open
+  bool public depositPaused;
+
+  /* CONSTANTS */
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+  bytes32 public constant PAUSER = keccak256("PAUSER");
+  bytes32 public constant BOT = keccak256("BOT");
+  uint256 public constant PRECISION = 1 ether;
+
+  /* EVENTS */
+  event Transfer(address indexed from, address indexed to, uint256 value);
+  event Deposit(address indexed user, uint256 amount);
+  event RequestWithdraw(address indexed owner, address indexed receiver, uint256 batchId, uint256 amount);
+  event FinishWithdraw(uint256 batchId, uint256 amount);
+  event ClaimWithdrawal(address indexed user, uint256 idx, uint256 amount);
+  event CancelWithdrawal(address indexed user, uint256 idx, uint256 amount);
+  event SetMinDeposit(uint256 minDeposit);
+  event SetMinWithdraw(uint256 minWithdraw);
+  event SetDailyLimit(uint256 dailyLimit);
+  event SetAdapter(address adapter);
+  event SetDepositPaused(bool paused);
+  event EmergencyWithdraw(address token, uint256 amount);
+
+  /* INITIALIZER */
+  function __CreditFundBase_init(
+    address _admin,
+    address _manager,
+    address _pauser,
+    address _bot,
+    address _asset,
+    address _adapter,
+    string memory _name,
+    string memory _symbol
+  ) internal onlyInitializing {
+    require(_admin != address(0), "admin is zero address");
+    require(_manager != address(0), "manager is zero address");
+    require(_pauser != address(0), "pauser is zero address");
+    require(_bot != address(0), "bot is zero address");
+    require(_asset != address(0), "asset is zero address");
+    require(_adapter != address(0), "adapter is zero address");
+    require(bytes(_name).length > 0, "name is empty");
+    require(bytes(_symbol).length > 0, "symbol is empty");
+
+    __AccessControlEnumerable_init();
+    __Pausable_init();
+    __ReentrancyGuard_init();
+
+    _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    _grantRole(MANAGER, _manager);
+    _grantRole(PAUSER, _pauser);
+    _grantRole(BOT, _bot);
+
+    asset = _asset;
+    adapter = _adapter;
+    name = _name;
+    symbol = _symbol;
+  }
+
+  /* MODIFIERS */
+  /// @dev gate for entry-side ops (deposits, locked early-redeem) during a wind-down
+  modifier whenDepositNotPaused() {
+    require(!depositPaused, "deposit paused");
+    _;
+  }
+
+  /* ABSTRACT */
+  /// @dev total user principal booked in the pool
+  function totalPrincipal() external view virtual returns (uint256);
+
+  /* ADAPTER-DRIVEN FUNCTIONS */
+  /**
+   * @dev repay the batch withdraw queue. Only the adapter can call.
+   * @param amount asset amount transferred in to cover pending batches (0 allowed to just tick batches)
+   */
+  function finishWithdraw(uint256 amount) external {
+    require(msg.sender == adapter, "only adapter can call");
+
+    if (amount > 0) {
+      IERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
+      withdrawQuota += amount;
+      // cap the received cash at the pool's real pending obligation so the adapter
+      // cannot over-push funds (relocating its floor/buffer) into the pool. Checked
+      // only on funding pushes (amount > 0); a 0-amount tick can always advance
+      // batches, so cancellations can never wedge batch confirmation.
+      require(withdrawQuota <= totalPendingWithdraw, "quota exceeds pending");
+    }
+
+    // confirm as many batches as the quota can fully cover, in order
+    for (uint256 i = confirmedBatchId + 1; i <= currentBatchId; i++) {
+      uint256 withdrawAmount = totalWithdrawAmountInBatch[i];
+      if (withdrawAmount > withdrawQuota) {
+        break;
+      }
+      confirmedBatchId = i;
+      withdrawQuota -= withdrawAmount;
+      emit FinishWithdraw(i, withdrawAmount);
+    }
+  }
+
+  /* USER FUNCTIONS */
+  /**
+   * @dev claim principal of a confirmed withdrawal request.
+   * @param user the owner of the request
+   * @param idx the index of the request
+   */
+  function claimWithdraw(address user, uint256 idx) external whenNotPaused nonReentrant {
+    uint256 amount = _consumeConfirmedWithdraw(user, idx);
+    IERC20(asset).safeTransfer(user, amount);
+
+    emit ClaimWithdrawal(user, idx, amount);
+  }
+
+  /* VIEWS */
+  function getUserWithdrawalRequests(address user) external view returns (WithdrawalRequest[] memory) {
+    return userWithdrawalRequests[user];
+  }
+
+  /// @dev mirror the underlying asset's decimals so the 1:1 LP renders correctly
+  ///      on each chain (BSC USDT 18, ETH USDT 6).
+  function decimals() external view returns (uint8) {
+    return IERC20Metadata(asset).decimals();
+  }
+
+  /* MANAGER FUNCTIONS */
+  function setMinDeposit(uint256 _minDeposit) external onlyRole(MANAGER) {
+    require(minDeposit != _minDeposit, "same minDeposit");
+    minDeposit = _minDeposit;
+    emit SetMinDeposit(_minDeposit);
+  }
+
+  function setMinWithdraw(uint256 _minWithdraw) external onlyRole(MANAGER) {
+    require(minWithdraw != _minWithdraw, "same minWithdraw");
+    minWithdraw = _minWithdraw;
+    emit SetMinWithdraw(_minWithdraw);
+  }
+
+  function setDailyLimit(uint256 _dailyLimit) external onlyRole(MANAGER) {
+    require(dailyLimit != _dailyLimit, "same dailyLimit");
+    dailyLimit = _dailyLimit;
+    emit SetDailyLimit(_dailyLimit);
+  }
+
+  function setDepositPaused(bool _paused) external onlyRole(MANAGER) {
+    require(depositPaused != _paused, "same status");
+    depositPaused = _paused;
+    emit SetDepositPaused(_paused);
+  }
+
+  function setAdapter(address _adapter) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_adapter != address(0), "adapter is zero address");
+    require(_adapter != adapter, "same adapter");
+    adapter = _adapter;
+    emit SetAdapter(_adapter);
+  }
+
+  function pause() external onlyRole(PAUSER) {
+    _pause();
+  }
+
+  function unpause() external onlyRole(MANAGER) {
+    _unpause();
+  }
+
+  /**
+   * @dev emergency token rescue. Interest/withdraw funds live in the pool, so
+   *      restrict to admin.
+   */
+  function emergencyWithdraw(address token, uint256 amount, address receiver) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(amount > 0, "amount is zero");
+    require(receiver != address(0), "receiver is zero address");
+    IERC20(token).safeTransfer(receiver, amount);
+    emit EmergencyWithdraw(token, amount);
+  }
+
+  /* INTERNAL HELPERS */
+  /**
+   * @dev enqueue a withdrawal request into the current/open batch.
+   * @param receiver the receiver of the payout
+   * @param amount the principal payout to queue
+   * @param cohortId source cohort for locked withdrawals (0 for flex, which has no cohorts)
+   */
+  function _enqueueWithdraw(address receiver, uint256 amount, uint256 cohortId) internal returns (uint256 batchId) {
+    // open a new batch on a new day, or when the current batch is already confirmed
+    uint256 day = block.timestamp / 1 days;
+    if (day > lastDay) {
+      lastDay = day;
+      ++currentBatchId;
+    } else if (currentBatchId == confirmedBatchId) {
+      ++currentBatchId;
+    }
+    batchId = currentBatchId;
+
+    userWithdrawalRequests[receiver].push(
+      WithdrawalRequest({ batchId: batchId, amount: amount, withdrawTime: block.timestamp, cohortId: cohortId })
+    );
+    totalWithdrawAmountInBatch[batchId] += amount;
+    totalPendingWithdraw += amount;
+  }
+
+  /**
+   * @dev remove an unconfirmed withdrawal request (for cancellation). Returns its amount.
+   */
+  function _removeWithdrawRequest(address user, uint256 idx) internal returns (uint256 amount) {
+    WithdrawalRequest[] storage reqs = userWithdrawalRequests[user];
+    require(idx < reqs.length, "invalid index");
+
+    WithdrawalRequest memory req = reqs[idx];
+    require(req.batchId > confirmedBatchId, "already confirmed");
+
+    reqs[idx] = reqs[reqs.length - 1];
+    reqs.pop();
+
+    totalWithdrawAmountInBatch[req.batchId] -= req.amount;
+    totalPendingWithdraw -= req.amount;
+    amount = req.amount;
+  }
+
+  /**
+   * @dev consume a confirmed (already-funded) withdrawal request: remove it and
+   *      decrement the pending total, returning its amount. Shared by claimWithdraw
+   *      (pays the user) and the locked pool's reinvest (rolls the funded principal
+   *      into a new term). The caller moves the cash after this returns.
+   */
+  function _consumeConfirmedWithdraw(address user, uint256 idx) internal returns (uint256 amount) {
+    WithdrawalRequest[] storage reqs = userWithdrawalRequests[user];
+    require(idx < reqs.length, "invalid index");
+
+    WithdrawalRequest memory req = reqs[idx];
+    require(req.batchId <= confirmedBatchId, "not able to claim yet");
+
+    // swap-pop remove
+    reqs[idx] = reqs[reqs.length - 1];
+    reqs.pop();
+
+    totalPendingWithdraw -= req.amount;
+    amount = req.amount;
+  }
+
+  /**
+   * @dev check and consume the per-address daily submit limit.
+   */
+  function _consumeDailyLimit(address user, uint256 amount) internal {
+    if (dailyLimit > 0) {
+      uint256 day = block.timestamp / 1 days;
+      require(dailySubmitted[day][user] + amount <= dailyLimit, "exceeds daily limit");
+      dailySubmitted[day][user] += amount;
+    }
+  }
+
+  /**
+   * @dev enforce the minimum-withdraw floor with a dust exit: a sub-minimum request
+   *      is only allowed when it drains the caller's whole remaining balance/position,
+   *      so a below-minimum remainder can never get stranded.
+   * @param amount the requested withdraw/redeem principal
+   * @param remaining the caller's full withdrawable balance/position principal
+   */
+  function _checkMinWithdraw(uint256 amount, uint256 remaining) internal view {
+    if (minWithdraw > 0 && amount < minWithdraw) {
+      require(amount == remaining, "below min withdraw");
+    }
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+  // reserve storage for future upgrades
+  uint256[47] private __gap;
+}

--- a/src/surfin/CreditFundBase.sol
+++ b/src/surfin/CreditFundBase.sol
@@ -83,6 +83,15 @@ abstract contract CreditFundBase is
   // mode); normal & matured withdrawals and claims stay open
   bool public depositPaused;
 
+  // principal belonging to batches already confirmed but not yet claimed. Splits
+  // `totalPendingWithdraw` into its two halves:
+  //     totalPendingWithdraw = unconfirmed obligation + totalConfirmedUnclaimed
+  // Only the unconfirmed half still needs cash from the adapter — the confirmed half is
+  // already sitting in this contract and must not license further quota. Declared last
+  // (rather than next to totalPendingWithdraw) so no existing storage slot shifts; one
+  // slot is taken from __gap below.
+  uint256 public totalConfirmedUnclaimed;
+
   /* CONSTANTS */
   bytes32 public constant MANAGER = keccak256("MANAGER");
   bytes32 public constant PAUSER = keccak256("PAUSER");
@@ -160,14 +169,40 @@ abstract contract CreditFundBase is
     if (amount > 0) {
       IERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
       withdrawQuota += amount;
-      // cap the received cash at the pool's real pending obligation so the adapter
-      // cannot over-push funds (relocating its floor/buffer) into the pool. Checked
-      // only on funding pushes (amount > 0); a 0-amount tick can always advance
+      // Cap the received cash at the obligation the adapter still owes cash for, so it
+      // cannot over-push funds (relocating its floor/buffer) into the pool.
+      //
+      // The bound is the UNCONFIRMED obligation, not totalPendingWithdraw: a confirmed
+      // batch's cash already sits in this contract, so counting it here would license a
+      // second, unbacked helping of quota. Under the wider bound a partial push followed
+      // by a cancellation left quota stranded behind the confirmed-unclaimed balance,
+      // invisible until the last claim dropped totalPendingWithdraw to 0.
+      //
+      // Checked only on funding pushes (amount > 0); a 0-amount tick can always advance
       // batches, so cancellations can never wedge batch confirmation.
-      require(withdrawQuota <= totalPendingWithdraw, "quota exceeds pending");
+      require(withdrawQuota <= _unconfirmedObligation(), "quota exceeds pending");
     }
 
-    // confirm as many batches as the quota can fully cover, in order
+    _confirmBatches();
+  }
+
+  /**
+   * @dev principal the adapter still has to send cash for: every queued request minus the
+   *      ones whose batch is already confirmed (whose payout is funded and waiting here).
+   *      Non-negative by construction — totalConfirmedUnclaimed only ever moves in lockstep
+   *      with a subset of totalPendingWithdraw — so the subtraction reverting would itself
+   *      signal broken accounting.
+   */
+  function _unconfirmedObligation() internal view returns (uint256) {
+    return totalPendingWithdraw - totalConfirmedUnclaimed;
+  }
+
+  /**
+   * @dev confirm as many batches as the quota can fully cover, in order. Shared by
+   *      finishWithdraw and adminTopUp so the two can never drift apart on the
+   *      totalConfirmedUnclaimed bookkeeping.
+   */
+  function _confirmBatches() internal {
     for (uint256 i = confirmedBatchId + 1; i <= currentBatchId; i++) {
       uint256 withdrawAmount = totalWithdrawAmountInBatch[i];
       if (withdrawAmount > withdrawQuota) {
@@ -175,6 +210,10 @@ abstract contract CreditFundBase is
       }
       confirmedBatchId = i;
       withdrawQuota -= withdrawAmount;
+      // the batch's payout is now funded and parked here awaiting claims: it leaves the
+      // unconfirmed obligation (which shrinks by the same amount the quota just did, so
+      // `withdrawQuota <= _unconfirmedObligation()` is preserved) and becomes claimable.
+      totalConfirmedUnclaimed += withdrawAmount;
       emit FinishWithdraw(i, withdrawAmount);
     }
   }
@@ -266,15 +305,7 @@ abstract contract CreditFundBase is
     IERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
     withdrawQuota += amount;
 
-    for (uint256 i = confirmedBatchId + 1; i <= currentBatchId; i++) {
-      uint256 withdrawAmount = totalWithdrawAmountInBatch[i];
-      if (withdrawAmount > withdrawQuota) {
-        break;
-      }
-      confirmedBatchId = i;
-      withdrawQuota -= withdrawAmount;
-      emit FinishWithdraw(i, withdrawAmount);
-    }
+    _confirmBatches();
   }
 
   /* INTERNAL HELPERS */
@@ -320,9 +351,21 @@ abstract contract CreditFundBase is
     totalPendingWithdraw -= req.amount;
     amount = req.amount;
 
-    // M02 fix: return orphaned quota to adapter to restore withdrawQuota <= totalPendingWithdraw
-    if (withdrawQuota > totalPendingWithdraw) {
-      uint256 excess = withdrawQuota - totalPendingWithdraw;
+    // M02 fix: a cancellation is the ONLY operation that shrinks the unconfirmed obligation
+    // without spending quota, so it is the only place quota can end up exceeding what the
+    // pool still owes cash for. Return the orphan to the adapter, where the floor is
+    // measured, restoring `withdrawQuota <= _unconfirmedObligation()`.
+    //
+    // Measured against the unconfirmed half, not totalPendingWithdraw: the wider predicate
+    // stays false while a confirmed-unclaimed balance masks the excess, so the orphan would
+    // survive here and only surface once the last claim drained the mask.
+    //
+    // Claims need no counterpart: _consumeConfirmedWithdraw shrinks totalPendingWithdraw
+    // and totalConfirmedUnclaimed together, leaving the unconfirmed half — and therefore
+    // this bound — untouched.
+    uint256 unconfirmed = _unconfirmedObligation();
+    if (withdrawQuota > unconfirmed) {
+      uint256 excess = withdrawQuota - unconfirmed;
       withdrawQuota -= excess;
       IERC20(asset).safeTransfer(adapter, excess);
     }
@@ -350,7 +393,11 @@ abstract contract CreditFundBase is
     reqs[idx] = reqs[reqs.length - 1];
     reqs.pop();
 
+    // Both halves shrink together: the payout was funded when its batch confirmed, so it
+    // leaves the queue and the confirmed-unclaimed book at once. The unconfirmed
+    // obligation is unchanged, so no quota can be orphaned here.
     totalPendingWithdraw -= req.amount;
+    totalConfirmedUnclaimed -= req.amount;
     amount = req.amount;
   }
 
@@ -381,5 +428,5 @@ abstract contract CreditFundBase is
   function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
   // reserve storage for future upgrades
-  uint256[47] private __gap;
+  uint256[46] private __gap;
 }

--- a/src/surfin/CreditFundBase.sol
+++ b/src/surfin/CreditFundBase.sol
@@ -182,10 +182,13 @@ abstract contract CreditFundBase is
   /* USER FUNCTIONS */
   /**
    * @dev claim principal of a confirmed withdrawal request.
+   *      Restricted to the request owner (or a BOT) to prevent third-party
+   *      front-running that mutates array indices via swap-and-pop.
    * @param user the owner of the request
    * @param idx the index of the request
    */
   function claimWithdraw(address user, uint256 idx) external whenNotPaused nonReentrant {
+    require(msg.sender == user || hasRole(BOT, msg.sender), "not authorized");
     uint256 amount = _consumeConfirmedWithdraw(user, idx);
     IERC20(asset).safeTransfer(user, amount);
 

--- a/src/surfin/CreditFundBase.sol
+++ b/src/surfin/CreditFundBase.sol
@@ -101,7 +101,7 @@ abstract contract CreditFundBase is
   event SetDailyLimit(uint256 dailyLimit);
   event SetAdapter(address adapter);
   event SetDepositPaused(bool paused);
-  event EmergencyWithdraw(address token, uint256 amount);
+  event EmergencyWithdraw(address indexed token, address indexed receiver, uint256 amount);
 
   /* INITIALIZER */
   function __CreditFundBase_init(
@@ -154,7 +154,7 @@ abstract contract CreditFundBase is
    * @dev repay the batch withdraw queue. Only the adapter can call.
    * @param amount asset amount transferred in to cover pending batches (0 allowed to just tick batches)
    */
-  function finishWithdraw(uint256 amount) external {
+  function finishWithdraw(uint256 amount) external nonReentrant {
     require(msg.sender == adapter, "only adapter can call");
 
     if (amount > 0) {
@@ -254,7 +254,7 @@ abstract contract CreditFundBase is
     require(amount > 0, "amount is zero");
     require(receiver != address(0), "receiver is zero address");
     IERC20(token).safeTransfer(receiver, amount);
-    emit EmergencyWithdraw(token, amount);
+    emit EmergencyWithdraw(token, receiver, amount);
   }
 
   /**

--- a/src/surfin/CreditFundBase.sol
+++ b/src/surfin/CreditFundBase.sol
@@ -187,9 +187,9 @@ abstract contract CreditFundBase is
    * @param user the owner of the request
    * @param idx the index of the request
    */
-  function claimWithdraw(address user, uint256 idx) external whenNotPaused nonReentrant {
+  function claimWithdraw(address user, uint256 idx, uint256 expectedAmount) external whenNotPaused nonReentrant {
     require(msg.sender == user || hasRole(BOT, msg.sender), "not authorized");
-    uint256 amount = _consumeConfirmedWithdraw(user, idx);
+    uint256 amount = _consumeConfirmedWithdraw(user, idx, expectedAmount);
     IERC20(asset).safeTransfer(user, amount);
 
     emit ClaimWithdrawal(user, idx, amount);
@@ -257,6 +257,26 @@ abstract contract CreditFundBase is
     emit EmergencyWithdraw(token, amount);
   }
 
+  /**
+   * @dev M03 fix: admin injects funds to cover shortfall when the fund is impaired,
+   *      bypassing the withdrawQuota <= totalPendingWithdraw cap so all batches can confirm.
+   */
+  function adminTopUp(uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
+    require(amount > 0, "amount is zero");
+    IERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
+    withdrawQuota += amount;
+
+    for (uint256 i = confirmedBatchId + 1; i <= currentBatchId; i++) {
+      uint256 withdrawAmount = totalWithdrawAmountInBatch[i];
+      if (withdrawAmount > withdrawQuota) {
+        break;
+      }
+      confirmedBatchId = i;
+      withdrawQuota -= withdrawAmount;
+      emit FinishWithdraw(i, withdrawAmount);
+    }
+  }
+
   /* INTERNAL HELPERS */
   /**
    * @dev enqueue a withdrawal request into the current/open batch.
@@ -285,11 +305,12 @@ abstract contract CreditFundBase is
   /**
    * @dev remove an unconfirmed withdrawal request (for cancellation). Returns its amount.
    */
-  function _removeWithdrawRequest(address user, uint256 idx) internal returns (uint256 amount) {
+  function _removeWithdrawRequest(address user, uint256 idx, uint256 expectedAmount) internal returns (uint256 amount) {
     WithdrawalRequest[] storage reqs = userWithdrawalRequests[user];
     require(idx < reqs.length, "invalid index");
 
     WithdrawalRequest memory req = reqs[idx];
+    require(req.amount == expectedAmount, "amount mismatch");
     require(req.batchId > confirmedBatchId, "already confirmed");
 
     reqs[idx] = reqs[reqs.length - 1];
@@ -298,6 +319,13 @@ abstract contract CreditFundBase is
     totalWithdrawAmountInBatch[req.batchId] -= req.amount;
     totalPendingWithdraw -= req.amount;
     amount = req.amount;
+
+    // M02 fix: return orphaned quota to adapter to restore withdrawQuota <= totalPendingWithdraw
+    if (withdrawQuota > totalPendingWithdraw) {
+      uint256 excess = withdrawQuota - totalPendingWithdraw;
+      withdrawQuota -= excess;
+      IERC20(asset).safeTransfer(adapter, excess);
+    }
   }
 
   /**
@@ -306,11 +334,16 @@ abstract contract CreditFundBase is
    *      (pays the user) and the locked pool's reinvest (rolls the funded principal
    *      into a new term). The caller moves the cash after this returns.
    */
-  function _consumeConfirmedWithdraw(address user, uint256 idx) internal returns (uint256 amount) {
+  function _consumeConfirmedWithdraw(
+    address user,
+    uint256 idx,
+    uint256 expectedAmount
+  ) internal returns (uint256 amount) {
     WithdrawalRequest[] storage reqs = userWithdrawalRequests[user];
     require(idx < reqs.length, "invalid index");
 
     WithdrawalRequest memory req = reqs[idx];
+    require(req.amount == expectedAmount, "amount mismatch");
     require(req.batchId <= confirmedBatchId, "not able to claim yet");
 
     // swap-pop remove

--- a/src/surfin/FlexEarnPool.sol
+++ b/src/surfin/FlexEarnPool.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { CreditFundBase } from "./CreditFundBase.sol";
+
+/**
+ * @title FlexEarnPool
+ * @notice Flexible (demand) product of the Surfin Credit Fund.
+ *
+ * Principal is tracked 1:1 as an LP balance (deposit mints, withdraw burns).
+ * Interest is distributed off-pool via the cumulative Merkle InterestDistributor.
+ * Withdrawals go through the shared daily batch queue; unconfirmed requests can
+ * be cancelled in full, restoring the LP with no interest loss.
+ */
+contract FlexEarnPool is CreditFundBase {
+  using SafeERC20 for IERC20;
+
+  /* VARIABLES */
+  // user => LP balance (1:1 with principal)
+  mapping(address => uint256) public balanceOf;
+  // total LP supply
+  uint256 public totalSupply;
+
+  /* CONSTRUCTOR */
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /* INITIALIZER */
+  function initialize(
+    address _admin,
+    address _manager,
+    address _pauser,
+    address _bot,
+    address _asset,
+    address _adapter,
+    string memory _name,
+    string memory _symbol
+  ) external initializer {
+    __CreditFundBase_init(_admin, _manager, _pauser, _bot, _asset, _adapter, _name, _symbol);
+  }
+
+  /* EXTERNAL FUNCTIONS */
+  /**
+   * @dev deposit asset into the flex pool; funds go straight to the adapter.
+   * @param amount the amount of asset to deposit
+   * @param receiver the receiver of the LP
+   */
+  function deposit(uint256 amount, address receiver) external whenNotPaused whenDepositNotPaused nonReentrant {
+    require(amount > 0, "amount is zero");
+    require(receiver != address(0), "receiver is zero address");
+    require(amount >= minDeposit, "deposit below minimum");
+
+    // mint 1:1 LP and forward funds to the adapter
+    _mint(receiver, amount);
+    IERC20(asset).safeTransferFrom(msg.sender, adapter, amount);
+
+    emit Deposit(receiver, amount);
+  }
+
+  /**
+   * @dev request to withdraw principal; burns LP and queues into the batch.
+   * @param amount the amount of principal to withdraw
+   */
+  function requestWithdraw(uint256 amount) external whenNotPaused nonReentrant {
+    require(amount > 0, "amount is zero");
+    require(balanceOf[msg.sender] >= amount, "insufficient balance");
+
+    // min-withdraw floor with dust exit: a sub-min request must drain the balance
+    _checkMinWithdraw(amount, balanceOf[msg.sender]);
+
+    // enforce per-address daily submit limit
+    _consumeDailyLimit(msg.sender, amount);
+
+    // burn LP and enqueue
+    _burn(msg.sender, amount);
+    uint256 batchId = _enqueueWithdraw(msg.sender, amount, 0);
+
+    emit RequestWithdraw(msg.sender, msg.sender, batchId, amount);
+  }
+
+  /**
+   * @dev cancel an unconfirmed withdrawal request in full; restores the LP.
+   * @param idx the index of the caller's withdrawal request
+   */
+  function cancelWithdraw(uint256 idx) external whenNotPaused nonReentrant {
+    uint256 amount = _removeWithdrawRequest(msg.sender, idx);
+    _mint(msg.sender, amount);
+
+    emit CancelWithdrawal(msg.sender, idx, amount);
+  }
+
+  /* VIEWS */
+  /// @inheritdoc CreditFundBase
+  function totalPrincipal() external view override returns (uint256) {
+    return totalSupply;
+  }
+
+  /* INTERNAL FUNCTIONS */
+  function _mint(address account, uint256 amount) internal {
+    require(account != address(0), "mint to the zero address");
+    balanceOf[account] += amount;
+    totalSupply += amount;
+    emit Transfer(address(0), account, amount);
+  }
+
+  function _burn(address account, uint256 amount) internal {
+    require(account != address(0), "burn from the zero address");
+    require(balanceOf[account] >= amount, "burn amount exceeds balance");
+    balanceOf[account] -= amount;
+    totalSupply -= amount;
+    emit Transfer(account, address(0), amount);
+  }
+}

--- a/src/surfin/FlexEarnPool.sol
+++ b/src/surfin/FlexEarnPool.sol
@@ -86,9 +86,10 @@ contract FlexEarnPool is CreditFundBase {
   /**
    * @dev cancel an unconfirmed withdrawal request in full; restores the LP.
    * @param idx the index of the caller's withdrawal request
+   * @param expectedAmount the expected request amount (M04 fix: prevents swap-and-pop mismatch)
    */
-  function cancelWithdraw(uint256 idx) external whenNotPaused nonReentrant {
-    uint256 amount = _removeWithdrawRequest(msg.sender, idx);
+  function cancelWithdraw(uint256 idx, uint256 expectedAmount) external whenNotPaused nonReentrant {
+    uint256 amount = _removeWithdrawRequest(msg.sender, idx, expectedAmount);
     _mint(msg.sender, amount);
 
     emit CancelWithdrawal(msg.sender, idx, amount);

--- a/src/surfin/FlexEarnPool.sol
+++ b/src/surfin/FlexEarnPool.sol
@@ -103,17 +103,17 @@ contract FlexEarnPool is CreditFundBase {
 
   /* INTERNAL FUNCTIONS */
   function _mint(address account, uint256 amount) internal {
-    require(account != address(0), "mint to the zero address");
     balanceOf[account] += amount;
     totalSupply += amount;
     emit Transfer(address(0), account, amount);
   }
 
   function _burn(address account, uint256 amount) internal {
-    require(account != address(0), "burn from the zero address");
     require(balanceOf[account] >= amount, "burn amount exceeds balance");
     balanceOf[account] -= amount;
     totalSupply -= amount;
     emit Transfer(account, address(0), amount);
   }
+
+  uint256[50] private __gap;
 }

--- a/src/surfin/InterestDistributor.sol
+++ b/src/surfin/InterestDistributor.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+import { IInterestDistributor } from "./interface/IInterestDistributor.sol";
+
+/**
+ * @title InterestDistributor
+ * @author Lista DAO
+ * @notice Cumulative-Merkle interest distributor for the Surfin Credit Fund.
+ *
+ * Models lista-new-contracts/src/LendingRewardsDistributorV2.sol:
+ *  - cumulative Merkle claims (the leaf carries the running total; the contract
+ *    stores the already-claimed amount and only pays the delta);
+ *  - a two-step, time-locked root update (setPendingMerkleRoot -> wait ->
+ *    acceptMerkleRoot) so a bad root can be revoked before it goes live.
+ *
+ * Unlike the lending distributor, funds are not sent here directly: they live on
+ * the SurfinAdapter, which tops this contract up via `notifyReward` (guarded by
+ * FUNDER role) before publishing each weekly root. Users then claim their
+ * cumulative interest directly from this contract.
+ */
+contract InterestDistributor is
+  IInterestDistributor,
+  AccessControlEnumerableUpgradeable,
+  PausableUpgradeable,
+  UUPSUpgradeable
+{
+  using SafeERC20 for IERC20;
+
+  /// @dev current merkle root
+  bytes32 public merkleRoot;
+
+  /// @dev the single interest token (USDT); leaves and payouts are denominated in it
+  address public token;
+
+  /// @dev userAddress => total claimed amount
+  mapping(address => uint256) public claimed;
+
+  /// @dev the next merkle root to be set
+  bytes32 public pendingMerkleRoot;
+
+  /// @dev last time pending merkle root was set
+  uint256 public lastSetTime;
+
+  /// @dev the waiting period before accepting the pending merkle root; 1 day by default
+  uint256 public waitingPeriod;
+
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+  bytes32 public constant BOT = keccak256("BOT");
+  bytes32 public constant PAUSER = keccak256("PAUSER");
+  bytes32 public constant FUNDER = keccak256("FUNDER");
+
+  event Claimed(address indexed account, uint256 amount, uint256 totalAmount);
+  event RewardFunded(address indexed funder, uint256 amount);
+  event SetPendingMerkleRoot(bytes32 merkleRoot, uint256 lastSetTime);
+  event AcceptMerkleRoot(bytes32 merkleRoot, uint256 acceptedTime);
+  event WaitingPeriodUpdated(uint256 waitingPeriod);
+  event EmergencyWithdrawal(address to, address token, uint256 amount);
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /**
+   * @param _admin Address of the admin
+   * @param _manager Address of the manager
+   * @param _bot Address of the bot
+   * @param _pauser Address of the pauser
+   * @param _funder Address allowed to fund interest (the SurfinAdapter)
+   * @param _token Address of the single interest token (USDT)
+   */
+  function initialize(
+    address _admin,
+    address _manager,
+    address _bot,
+    address _pauser,
+    address _funder,
+    address _token
+  ) external initializer {
+    require(_admin != address(0), "Invalid admin address");
+    require(_manager != address(0), "Invalid manager address");
+    require(_bot != address(0), "Invalid bot address");
+    require(_pauser != address(0), "Invalid pauser address");
+    require(_funder != address(0), "Invalid funder address");
+    require(_token != address(0), "Invalid token address");
+
+    __Pausable_init();
+    __AccessControl_init();
+
+    lastSetTime = type(uint256).max;
+    waitingPeriod = 6 hours;
+
+    token = _token;
+
+    _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    _grantRole(MANAGER, _manager);
+    _grantRole(BOT, _bot);
+    _grantRole(PAUSER, _pauser);
+    _grantRole(FUNDER, _funder);
+  }
+
+  /**
+   * @dev fund the distributor with interest to distribute. Only the funder (the
+   *      SurfinAdapter) can call; it pulls `amount` of the interest token from itself.
+   * @param amount Amount of interest to fund
+   */
+  function notifyReward(uint256 amount) external onlyRole(FUNDER) whenNotPaused {
+    require(amount > 0, "Invalid amount");
+
+    IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+
+    emit RewardFunded(msg.sender, amount);
+  }
+
+  /**
+   * @dev Batch claim interest. Can be called by anyone as long as proof is valid.
+   * @param _accounts Addresses of claiming accounts
+   * @param _totalAmounts Total amounts of interest claimable by the accounts
+   * @param _proofs Merkle proofs of the claims
+   */
+  function batchClaim(address[] memory _accounts, uint256[] memory _totalAmounts, bytes32[][] memory _proofs) external {
+    require(_accounts.length == _totalAmounts.length && _accounts.length == _proofs.length, "Invalid input lengths");
+
+    for (uint256 i = 0; i < _accounts.length; i++) {
+      claim(_accounts[i], _totalAmounts[i], _proofs[i]);
+    }
+  }
+
+  /**
+   * @dev Claim interest. Can be called by anyone as long as proof is valid.
+   * @param _account Address of the claiming account
+   * @param _totalAmount total amount of interest claimable by the account
+   * @param _proof Merkle proof of the claim
+   */
+  function claim(address _account, uint256 _totalAmount, bytes32[] memory _proof) public whenNotPaused {
+    require(merkleRoot != bytes32(0), "Invalid merkle root");
+
+    uint256 claimedAmount = claimed[_account];
+    require(_totalAmount > claimedAmount, "Invalid total amount");
+
+    bytes32 leaf = keccak256(abi.encode(block.chainid, address(this), this.claim.selector, _account, _totalAmount));
+
+    require(MerkleProof.verify(_proof, merkleRoot, leaf), "Invalid proof");
+
+    claimed[_account] = _totalAmount;
+
+    uint256 amount = _totalAmount - claimedAmount;
+    if (amount > 0) IERC20(token).safeTransfer(_account, amount);
+
+    emit Claimed(_account, amount, _totalAmount);
+  }
+
+  /// @dev Set pending merkle root.
+  /// @param _merkleRoot New merkle root to be set as pending
+  function setPendingMerkleRoot(bytes32 _merkleRoot) external onlyRole(BOT) whenNotPaused {
+    require(
+      _merkleRoot != bytes32(0) &&
+        _merkleRoot != pendingMerkleRoot &&
+        _merkleRoot != merkleRoot &&
+        lastSetTime == type(uint256).max,
+      "Invalid new merkle root"
+    );
+
+    pendingMerkleRoot = _merkleRoot;
+    lastSetTime = block.timestamp;
+
+    emit SetPendingMerkleRoot(_merkleRoot, lastSetTime);
+  }
+
+  /// @dev Accept the pending merkle root; pending merkle root can only be accepted after the waiting period
+  function acceptMerkleRoot() external onlyRole(BOT) whenNotPaused {
+    require(pendingMerkleRoot != bytes32(0) && pendingMerkleRoot != merkleRoot, "Invalid pending merkle root");
+    require(block.timestamp >= lastSetTime + waitingPeriod, "Not ready to accept");
+
+    merkleRoot = pendingMerkleRoot;
+    pendingMerkleRoot = bytes32(0);
+    lastSetTime = type(uint256).max;
+
+    emit AcceptMerkleRoot(merkleRoot, block.timestamp);
+  }
+
+  /// @dev Revoke the pending merkle root by Manager
+  function revokePendingMerkleRoot() external onlyRole(MANAGER) {
+    require(pendingMerkleRoot != bytes32(0), "Pending merkle root is zero");
+
+    pendingMerkleRoot = bytes32(0);
+    lastSetTime = type(uint256).max;
+
+    emit SetPendingMerkleRoot(bytes32(0), lastSetTime);
+  }
+
+  /// @dev Change waiting period.
+  /// @param _waitingPeriod Waiting period to be set
+  function changeWaitingPeriod(uint256 _waitingPeriod) external onlyRole(MANAGER) whenNotPaused {
+    require(_waitingPeriod >= 6 hours && _waitingPeriod != waitingPeriod, "Invalid waiting period");
+    waitingPeriod = _waitingPeriod;
+
+    emit WaitingPeriodUpdated(_waitingPeriod);
+  }
+
+  /// @dev manager can withdraw all interest tokens from the contract in case of emergency
+  /// @param _token Address of the token to withdraw
+  function emergencyWithdraw(address _token) external onlyRole(MANAGER) {
+    uint256 _amount = IERC20(_token).balanceOf(address(this));
+    IERC20(_token).safeTransfer(msg.sender, _amount);
+
+    emit EmergencyWithdrawal(msg.sender, _token, _amount);
+  }
+
+  /// @dev pause the contract
+  function pause() external onlyRole(PAUSER) {
+    _pause();
+  }
+
+  /// @dev unpause the contract
+  function unpause() external onlyRole(MANAGER) {
+    _unpause();
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/src/surfin/InterestDistributor.sol
+++ b/src/surfin/InterestDistributor.sol
@@ -49,7 +49,7 @@ contract InterestDistributor is
   /// @dev last time pending merkle root was set
   uint256 public lastSetTime;
 
-  /// @dev the waiting period before accepting the pending merkle root; 1 day by default
+  /// @dev the waiting period before accepting the pending merkle root; 6 hours by default
   uint256 public waitingPeriod;
 
   bytes32 public constant MANAGER = keccak256("MANAGER");
@@ -93,7 +93,7 @@ contract InterestDistributor is
     require(_token != address(0), "Invalid token address");
 
     __Pausable_init();
-    __AccessControl_init();
+    __AccessControlEnumerable_init();
 
     lastSetTime = type(uint256).max;
     waitingPeriod = 6 hours;
@@ -153,7 +153,7 @@ contract InterestDistributor is
     claimed[_account] = _totalAmount;
 
     uint256 amount = _totalAmount - claimedAmount;
-    if (amount > 0) IERC20(token).safeTransfer(_account, amount);
+    IERC20(token).safeTransfer(_account, amount);
 
     emit Claimed(_account, amount, _totalAmount);
   }
@@ -200,7 +200,10 @@ contract InterestDistributor is
   /// @dev Change waiting period.
   /// @param _waitingPeriod Waiting period to be set
   function changeWaitingPeriod(uint256 _waitingPeriod) external onlyRole(MANAGER) whenNotPaused {
-    require(_waitingPeriod >= 6 hours && _waitingPeriod != waitingPeriod, "Invalid waiting period");
+    require(
+      _waitingPeriod >= 6 hours && _waitingPeriod <= 7 days && _waitingPeriod != waitingPeriod,
+      "Invalid waiting period"
+    );
     waitingPeriod = _waitingPeriod;
 
     emit WaitingPeriodUpdated(_waitingPeriod);
@@ -226,4 +229,6 @@ contract InterestDistributor is
   }
 
   function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+  uint256[50] private __gap;
 }

--- a/src/surfin/LockedEarnPool.sol
+++ b/src/surfin/LockedEarnPool.sol
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { CreditFundBase } from "./CreditFundBase.sol";
+
+/**
+ * @title LockedEarnPool
+ * @notice Locked (term) product of the Surfin Credit Fund (e.g. 3M+, 6M+).
+ *
+ * Each deposit joins a cohort (issuance batch). The cohort carries the
+ * settlement-aligned interest-start and maturity dates, injected
+ * off-chain by the manager and bounded on-chain, so every position in a batch
+ * shares the same schedule and one update covers them all. Early redemption
+ * (partial allowed) forfeits all interest and, if made within PENALTY_WINDOW of
+ * deposit, deducts a flat `penaltyRate` on the redeemed principal; past the
+ * window the full principal is returned. Interest (base + loyalty) is distributed
+ * off-pool via the cumulative Merkle InterestDistributor; renewal rolls the
+ * principal only into a fresh cohort.
+ */
+contract LockedEarnPool is CreditFundBase {
+  using SafeERC20 for IERC20;
+
+  /* STRUCTS */
+  // a single locked position (dates live on the referenced cohort)
+  struct Position {
+    uint256 principal; // principal amount
+    uint256 cohortId; // issuance batch this position belongs to
+    uint256 depositTime; // position creation time; early-redeem penalty window anchor
+    bool autoRenew; // roll principal into a new term on maturity
+    bool closed; // position terminated (redeemed / matured-out / renewed)
+  }
+
+  // an issuance batch (cohort). Dates are settlement-aligned and injected
+  // off-chain by the manager; all positions in a cohort share them, so one
+  // update covers the whole batch ("same batch, same maturity").
+  struct Cohort {
+    uint256 termDays; // nominal lock term in days (bounds the maturity)
+    uint256 depositDeadline; // deposits accepted until this time
+    uint256 maturityTime; // maturity date (settlement-aligned)
+    bool enabled; // open for deposit
+  }
+
+  /* CONSTANTS */
+  // early-redeem penalty applies to redemptions within this window from deposit
+  uint256 public constant PENALTY_WINDOW = 30 days;
+  // guardrail: highest early-redeem penalty rate the manager can set (1e18 = 100%)
+  uint256 public constant MAX_PENALTY_RATE = 0.1 ether;
+  // guardrail: maturity can be at most this far past the nominal term end
+  uint256 public constant MAX_ALIGN_WINDOW = 31 days;
+  // auto-renew is locked within this window before maturity (T-32 checkpoint)
+  uint256 public constant AUTO_RENEW_LOCK_WINDOW = 32 days;
+
+  /* VARIABLES */
+  // user => positions
+  mapping(address => Position[]) internal userPositions;
+  // total principal across all open positions
+  uint256 public totalPrincipalAmount;
+  // cohort id => issuance batch config
+  mapping(uint256 => Cohort) public cohorts;
+  // early-redeem penalty rate on redeemed principal, 1e18 (e.g. 0.008e18 = 0.8%)
+  uint256 public penaltyRate;
+
+  /* EVENTS */
+  event LockedDeposit(address indexed user, uint256 posId, uint256 cohortId, uint256 amount, uint256 maturityTime);
+  event RequestEarlyRedeem(address indexed user, uint256 posId, uint256 principal, uint256 batchId, uint256 payout);
+  event RequestMaturityWithdraw(address indexed user, uint256 posId, uint256 principal, uint256 batchId);
+  event RenewPosition(address indexed user, uint256 oldPosId, uint256 newPosId, uint256 principal);
+  event Reinvest(address indexed user, uint256 idx, uint256 newCohortId, uint256 newPosId, uint256 principal);
+  event ToggleAutoRenew(address indexed user, uint256 posId, bool autoRenew);
+  event SetCohort(uint256 cohortId, uint256 termDays, uint256 depositDeadline, uint256 maturityTime, bool enabled);
+  event SetPenaltyRate(uint256 penaltyRate);
+
+  /* CONSTRUCTOR */
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /* INITIALIZER */
+  function initialize(
+    address _admin,
+    address _manager,
+    address _pauser,
+    address _bot,
+    address _asset,
+    address _adapter,
+    string memory _name,
+    string memory _symbol
+  ) external initializer {
+    __CreditFundBase_init(_admin, _manager, _pauser, _bot, _asset, _adapter, _name, _symbol);
+    penaltyRate = 0.008 ether; // 0.8% default early-redeem penalty
+  }
+
+  /* EXTERNAL FUNCTIONS */
+  /**
+   * @dev deposit into a cohort; funds go straight to the adapter.
+   * @param cohortId the issuance batch id
+   * @param amount the amount of asset to deposit
+   * @param receiver the owner of the new position
+   * @param autoRenew whether to auto-renew the position on maturity
+   */
+  function deposit(
+    uint256 cohortId,
+    uint256 amount,
+    address receiver,
+    bool autoRenew
+  ) external whenNotPaused whenDepositNotPaused nonReentrant {
+    Cohort memory c = cohorts[cohortId];
+    require(c.enabled, "cohort not enabled");
+    require(block.timestamp <= c.depositDeadline, "deposit window closed");
+    require(amount > 0, "amount is zero");
+    require(receiver != address(0), "receiver is zero address");
+    require(amount >= minDeposit, "deposit below minimum");
+
+    userPositions[receiver].push(
+      Position({
+        principal: amount,
+        cohortId: cohortId,
+        depositTime: block.timestamp,
+        autoRenew: autoRenew,
+        closed: false
+      })
+    );
+    totalPrincipalAmount += amount;
+
+    IERC20(asset).safeTransferFrom(msg.sender, adapter, amount);
+
+    emit LockedDeposit(receiver, userPositions[receiver].length - 1, cohortId, amount, c.maturityTime);
+  }
+
+  /**
+   * @dev request early redemption of `amount` principal from a position (partial
+   *      allowed). All interest is forfeited; if redeemed within PENALTY_WINDOW of
+   *      deposit, a flat `penaltyRate` on the redeemed principal is deducted. The
+   *      payout enters the batch queue. The position stays open with reduced
+   *      principal, or is closed once fully redeemed.
+   * @param posId the caller's position id
+   * @param amount the principal amount to early-redeem
+   */
+  function requestEarlyRedeem(uint256 posId, uint256 amount) external whenNotPaused whenDepositNotPaused nonReentrant {
+    Position storage pos = userPositions[msg.sender][posId];
+    require(pos.principal > 0 && !pos.closed, "invalid position");
+    require(amount > 0 && amount <= pos.principal, "invalid amount");
+
+    // min-withdraw floor with dust exit: a sub-min redeem must clear the position
+    _checkMinWithdraw(amount, pos.principal);
+
+    uint256 cohortId = pos.cohortId;
+    require(block.timestamp < cohorts[cohortId].maturityTime, "already matured");
+
+    uint256 payout = _earlyRedeemPayout(pos.depositTime, amount);
+
+    pos.principal -= amount;
+    if (pos.principal == 0) {
+      pos.closed = true;
+    }
+    totalPrincipalAmount -= amount;
+
+    _consumeDailyLimit(msg.sender, payout);
+    uint256 batchId = _enqueueWithdraw(msg.sender, payout, cohortId);
+
+    emit RequestEarlyRedeem(msg.sender, posId, amount, batchId, payout);
+  }
+
+  /**
+   * @dev request withdraw of a matured position (only when not auto-renewing).
+   *      Principal enters the batch queue. No daily limit is applied to matured
+   *      principal.
+   * @param posId the caller's position id
+   */
+  function requestMaturityWithdraw(uint256 posId) external whenNotPaused nonReentrant {
+    _requestMaturityWithdraw(msg.sender, posId);
+  }
+
+  /**
+   * @dev BOT enqueues matured positions on behalf of users. The UI does not expose
+   *      a maturity-withdraw button, so users would otherwise never queue their
+   *      matured principal; the settlement-day job (BOT) does it for them and the
+   *      platform covers the gas. Run early each month once positions have matured.
+   *      Each entry follows the same rules as the user path (matured, not
+   *      auto-renewing); withdrawTime is the BOT call time (after maturity, so it
+   *      reads as a normal redemption). Reverts atomically on any invalid entry so
+   *      a BOT list-building bug surfaces instead of being silently skipped.
+   * @param users the position owners
+   * @param posIds the matching position ids
+   */
+  function batchRequestMaturityWithdraw(
+    address[] calldata users,
+    uint256[] calldata posIds
+  ) external whenNotPaused onlyRole(BOT) nonReentrant {
+    require(users.length == posIds.length, "length mismatch");
+    for (uint256 i = 0; i < users.length; i++) {
+      _requestMaturityWithdraw(users[i], posIds[i]);
+    }
+  }
+
+  /**
+   * @dev shared matured-withdraw path: close the position and queue its principal.
+   *      Called for the owner (user path) or on their behalf (BOT batch path).
+   * @param user the position owner
+   * @param posId the position id
+   */
+  function _requestMaturityWithdraw(address user, uint256 posId) internal {
+    Position storage pos = userPositions[user][posId];
+    require(pos.principal > 0 && !pos.closed, "invalid position");
+    require(block.timestamp >= cohorts[pos.cohortId].maturityTime, "not matured");
+    require(!pos.autoRenew, "auto renew on");
+
+    uint256 principal = pos.principal;
+    uint256 cohortId = pos.cohortId;
+    pos.closed = true;
+    totalPrincipalAmount -= principal;
+
+    uint256 batchId = _enqueueWithdraw(user, principal, cohortId);
+
+    emit RequestMaturityWithdraw(user, posId, principal, batchId);
+  }
+
+  /**
+   * @dev toggle auto-renew for a position. Enforced on-chain to be locked from the
+   *      T-30 checkpoint: no changes are allowed within AUTO_RENEW_LOCK_WINDOW of
+   *      maturity, so the settlement-day job can rely on a stable auto-renew flag.
+   * @param posId the caller's position id
+   */
+  function toggleAutoRenew(uint256 posId) external whenNotPaused {
+    Position storage pos = userPositions[msg.sender][posId];
+    require(pos.principal > 0 && !pos.closed, "invalid position");
+    require(block.timestamp + AUTO_RENEW_LOCK_WINDOW < cohorts[pos.cohortId].maturityTime, "auto renew locked (T-30)");
+
+    pos.autoRenew = !pos.autoRenew;
+    emit ToggleAutoRenew(msg.sender, posId, pos.autoRenew);
+  }
+
+  /**
+   * @dev roll a matured auto-renew position's principal into a fresh cohort.
+   *      Only principal is rolled (interest is distributed separately). Renewal
+   *      is limited to one term: the new position has auto-renew forced off.
+   *      Driven by the settlement-day job (BOT).
+   * @param user the position owner
+   * @param posId the matured position id
+   * @param newCohortId the cohort to renew into
+   */
+  function renewPosition(address user, uint256 posId, uint256 newCohortId) external onlyRole(BOT) nonReentrant {
+    Position storage pos = userPositions[user][posId];
+    require(pos.principal > 0 && !pos.closed, "invalid position");
+    require(pos.autoRenew, "auto renew off");
+    require(block.timestamp >= cohorts[pos.cohortId].maturityTime, "not matured");
+
+    Cohort memory c = cohorts[newCohortId];
+    require(c.enabled, "cohort not enabled");
+
+    uint256 principal = pos.principal;
+    pos.closed = true;
+
+    userPositions[user].push(
+      Position({
+        principal: principal,
+        cohortId: newCohortId,
+        depositTime: block.timestamp,
+        autoRenew: false,
+        closed: false
+      })
+    );
+    // totalPrincipalAmount unchanged: principal moves from old to new position
+
+    emit RenewPosition(user, posId, userPositions[user].length - 1, principal);
+  }
+
+  /**
+   * @dev one-click reinvest: roll an already-funded (claimable) withdrawal payout
+   *      into a fresh locked cohort instead of claiming it to the wallet. Offered on
+   *      the position page after settlement-day funding (finishWithdraw), as the peer
+   *      alternative to claimWithdraw. Only principal is rolled (interest is
+   *      distributed separately). Renewal is limited to one term: the new position
+   *      has auto-renew forced off. Blocked during wind-down (whenDepositNotPaused),
+   *      which leaves claimWithdraw as the only exit.
+   * @param idx the caller's confirmed (funded) withdrawal request index
+   * @param newCohortId the cohort to reinvest into
+   */
+  function reinvest(uint256 idx, uint256 newCohortId) external whenNotPaused whenDepositNotPaused nonReentrant {
+    Cohort memory c = cohorts[newCohortId];
+    require(c.enabled, "cohort not enabled");
+    require(block.timestamp <= c.depositDeadline, "deposit window closed");
+
+    // consume the funded payout (same gate as claimWithdraw); its cash was pushed
+    // into the pool by finishWithdraw and is sitting here now
+    uint256 principal = _consumeConfirmedWithdraw(msg.sender, idx);
+    require(principal >= minDeposit, "deposit below minimum");
+
+    // book the new position first (CEI: all state settled before the external transfer)
+    userPositions[msg.sender].push(
+      Position({
+        principal: principal,
+        cohortId: newCohortId,
+        depositTime: block.timestamp,
+        autoRenew: false,
+        closed: false
+      })
+    );
+    totalPrincipalAmount += principal;
+
+    // return the funded cash to the adapter so reinvested principal follows the same
+    // custody path as a fresh deposit
+    IERC20(asset).safeTransfer(adapter, principal);
+
+    emit Reinvest(msg.sender, idx, newCohortId, userPositions[msg.sender].length - 1, principal);
+  }
+
+  /* VIEWS */
+  /// @inheritdoc CreditFundBase
+  function totalPrincipal() external view override returns (uint256) {
+    return totalPrincipalAmount;
+  }
+
+  function getUserPositions(address user) external view returns (Position[] memory) {
+    return userPositions[user];
+  }
+
+  /**
+   * @dev preview the early-redeem payout for `amount` principal of a position.
+   */
+  function previewEarlyRedeem(address user, uint256 posId, uint256 amount) external view returns (uint256) {
+    Position memory pos = userPositions[user][posId];
+    return _earlyRedeemPayout(pos.depositTime, amount);
+  }
+
+  /* MANAGER FUNCTIONS */
+  /**
+   * @dev create or adjust a cohort (issuance batch). Dates are injected off-chain
+   *      but bounded on-chain: the maturity must land between the nominal term end
+   *      (deposit deadline + term) and MAX_ALIGN_WINDOW past it. This guardrail
+   *      keeps the manager from arbitrarily extending or shortening positions.
+   * @param cohortId the cohort id
+   * @param termDays nominal lock term in days
+   * @param depositDeadline last time deposits are accepted into this cohort
+   * @param maturityTime maturity date (settlement-aligned)
+   * @param enabled whether the cohort is open for deposit
+   */
+  function setCohort(
+    uint256 cohortId,
+    uint256 termDays,
+    uint256 depositDeadline,
+    uint256 maturityTime,
+    bool enabled
+  ) external onlyRole(BOT) {
+    require(termDays > 0, "term is zero");
+    uint256 nominalEnd = depositDeadline + termDays * 1 days;
+    require(maturityTime >= nominalEnd, "maturity before term end");
+    require(maturityTime <= nominalEnd + MAX_ALIGN_WINDOW, "maturity too late");
+
+    cohorts[cohortId] = Cohort({
+      termDays: termDays,
+      depositDeadline: depositDeadline,
+      maturityTime: maturityTime,
+      enabled: enabled
+    });
+    emit SetCohort(cohortId, termDays, depositDeadline, maturityTime, enabled);
+  }
+
+  /**
+   * @dev set the early-redeem penalty rate charged on redeemed principal (1e18 =
+   *      100%), bounded by MAX_PENALTY_RATE. Applies to redemptions within
+   *      PENALTY_WINDOW of deposit.
+   * @param _penaltyRate the new penalty rate, 1e18
+   */
+  function setPenaltyRate(uint256 _penaltyRate) external onlyRole(MANAGER) {
+    require(_penaltyRate <= MAX_PENALTY_RATE, "penalty rate too high");
+    penaltyRate = _penaltyRate;
+    emit SetPenaltyRate(_penaltyRate);
+  }
+
+  /* INTERNAL FUNCTIONS */
+  /**
+   * @dev early-redeem payout on `amount` principal. Within PENALTY_WINDOW of the
+   *      position's deposit time a flat `penaltyRate` is charged on the redeemed
+   *      principal; past the window the full principal is returned. Interest is
+   *      always forfeited on early redemption (distributed off-pool).
+   *      payout = amount - (amount * penaltyRate / PRECISION)  [within window]
+   *      payout = amount                                        [after window]
+   */
+  function _earlyRedeemPayout(uint256 depositTime, uint256 amount) internal view returns (uint256) {
+    if (block.timestamp < depositTime + PENALTY_WINDOW) {
+      uint256 penalty = (amount * penaltyRate) / PRECISION;
+      return amount - penalty;
+    }
+    return amount;
+  }
+}

--- a/src/surfin/LockedEarnPool.sol
+++ b/src/surfin/LockedEarnPool.sol
@@ -52,6 +52,8 @@ contract LockedEarnPool is CreditFundBase {
   uint256 public constant MAX_ALIGN_WINDOW = 31 days;
   // auto-renew is locked within this window before maturity (T-32 checkpoint)
   uint256 public constant AUTO_RENEW_LOCK_WINDOW = 32 days;
+  // upper bound on termDays to prevent absurd lock durations
+  uint256 public constant MAX_TERM_DAYS = 366;
 
   /* VARIABLES */
   // user => positions
@@ -280,14 +282,18 @@ contract LockedEarnPool is CreditFundBase {
    * @param idx the caller's confirmed (funded) withdrawal request index
    * @param newCohortId the cohort to reinvest into
    */
-  function reinvest(uint256 idx, uint256 newCohortId) external whenNotPaused whenDepositNotPaused nonReentrant {
+  function reinvest(
+    uint256 idx,
+    uint256 newCohortId,
+    uint256 expectedAmount
+  ) external whenNotPaused whenDepositNotPaused nonReentrant {
     Cohort memory c = cohorts[newCohortId];
     require(c.enabled, "cohort not enabled");
     require(block.timestamp <= c.depositDeadline, "deposit window closed");
 
     // consume the funded payout (same gate as claimWithdraw); its cash was pushed
     // into the pool by finishWithdraw and is sitting here now
-    uint256 principal = _consumeConfirmedWithdraw(msg.sender, idx);
+    uint256 principal = _consumeConfirmedWithdraw(msg.sender, idx, expectedAmount);
     require(principal >= minDeposit, "deposit below minimum");
 
     // book the new position first (CEI: all state settled before the external transfer)
@@ -330,9 +336,10 @@ contract LockedEarnPool is CreditFundBase {
   /* MANAGER FUNCTIONS */
   /**
    * @dev create or adjust a cohort (issuance batch). Dates are injected off-chain
-   *      but bounded on-chain: the maturity must land between the nominal term end
-   *      (deposit deadline + term) and MAX_ALIGN_WINDOW past it. This guardrail
-   *      keeps the manager from arbitrarily extending or shortening positions.
+   *      but bounded on-chain. Access control is split per the audit recommendation:
+   *      - BOT may create new cohorts or toggle the enabled flag of existing ones.
+   *      - Only MANAGER may modify the dates of an existing cohort, and the new
+   *        maturityTime is anchored to the stored value (±MAX_ALIGN_WINDOW).
    * @param cohortId the cohort id
    * @param termDays nominal lock term in days
    * @param depositDeadline last time deposits are accepted into this cohort
@@ -345,11 +352,31 @@ contract LockedEarnPool is CreditFundBase {
     uint256 depositDeadline,
     uint256 maturityTime,
     bool enabled
-  ) external onlyRole(BOT) {
+  ) external {
     require(termDays > 0, "term is zero");
+    require(termDays <= MAX_TERM_DAYS, "term too long");
     uint256 nominalEnd = depositDeadline + termDays * 1 days;
     require(maturityTime >= nominalEnd, "maturity before term end");
     require(maturityTime <= nominalEnd + MAX_ALIGN_WINDOW, "maturity too late");
+
+    Cohort storage existing = cohorts[cohortId];
+
+    if (existing.termDays == 0) {
+      // new cohort: BOT can create
+      _checkRole(BOT);
+    } else if (
+      termDays == existing.termDays &&
+      depositDeadline == existing.depositDeadline &&
+      maturityTime == existing.maturityTime
+    ) {
+      // only toggling enabled flag: BOT can do this
+      _checkRole(BOT);
+    } else {
+      // modifying dates of existing cohort: MANAGER only, anchored to stored maturity
+      _checkRole(MANAGER);
+      require(maturityTime <= existing.maturityTime + MAX_ALIGN_WINDOW, "maturity drift too late");
+      require(maturityTime + MAX_ALIGN_WINDOW >= existing.maturityTime, "maturity drift too early");
+    }
 
     cohorts[cohortId] = Cohort({
       termDays: termDays,

--- a/src/surfin/LockedEarnPool.sol
+++ b/src/surfin/LockedEarnPool.sol
@@ -195,6 +195,11 @@ contract LockedEarnPool is CreditFundBase {
   ) external whenNotPaused onlyRole(BOT) nonReentrant {
     require(users.length == posIds.length, "length mismatch");
     for (uint256 i = 0; i < users.length; i++) {
+      Position storage pos = userPositions[users[i]][posIds[i]];
+      // skip already-closed or not-yet-matured positions instead of reverting the whole batch
+      if (pos.principal == 0 || pos.closed) continue;
+      if (block.timestamp < cohorts[pos.cohortId].maturityTime) continue;
+      if (pos.autoRenew) continue;
       _requestMaturityWithdraw(users[i], posIds[i]);
     }
   }
@@ -245,7 +250,11 @@ contract LockedEarnPool is CreditFundBase {
    * @param posId the matured position id
    * @param newCohortId the cohort to renew into
    */
-  function renewPosition(address user, uint256 posId, uint256 newCohortId) external onlyRole(BOT) nonReentrant {
+  function renewPosition(
+    address user,
+    uint256 posId,
+    uint256 newCohortId
+  ) external onlyRole(BOT) whenNotPaused whenDepositNotPaused nonReentrant {
     Position storage pos = userPositions[user][posId];
     require(pos.principal > 0 && !pos.closed, "invalid position");
     require(pos.autoRenew, "auto renew off");
@@ -353,7 +362,7 @@ contract LockedEarnPool is CreditFundBase {
     uint256 maturityTime,
     bool enabled
   ) external {
-    require(termDays > 0, "term is zero");
+    require(termDays > AUTO_RENEW_LOCK_WINDOW / 1 days, "term too short");
     require(termDays <= MAX_TERM_DAYS, "term too long");
     uint256 nominalEnd = depositDeadline + termDays * 1 days;
     require(maturityTime >= nominalEnd, "maturity before term end");

--- a/src/surfin/LockedEarnPool.sol
+++ b/src/surfin/LockedEarnPool.sol
@@ -94,6 +94,7 @@ contract LockedEarnPool is CreditFundBase {
   ) external initializer {
     __CreditFundBase_init(_admin, _manager, _pauser, _bot, _asset, _adapter, _name, _symbol);
     penaltyRate = 0.008 ether; // 0.8% default early-redeem penalty
+    emit SetPenaltyRate(penaltyRate);
   }
 
   /* EXTERNAL FUNCTIONS */
@@ -339,6 +340,8 @@ contract LockedEarnPool is CreditFundBase {
    */
   function previewEarlyRedeem(address user, uint256 posId, uint256 amount) external view returns (uint256) {
     Position memory pos = userPositions[user][posId];
+    require(pos.principal > 0 && !pos.closed, "invalid position");
+    require(amount <= pos.principal, "amount exceeds principal");
     return _earlyRedeemPayout(pos.depositTime, amount);
   }
 
@@ -424,4 +427,6 @@ contract LockedEarnPool is CreditFundBase {
     }
     return amount;
   }
+
+  uint256[50] private __gap;
 }

--- a/src/surfin/SurfinAdapter.sol
+++ b/src/surfin/SurfinAdapter.sol
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { ICreditFundPool } from "./interface/ICreditFundPool.sol";
+import { IInterestDistributor } from "./interface/IInterestDistributor.sol";
+
+/**
+ * @title SurfinAdapter
+ * @notice Shared adapter for the Surfin Credit Fund, following the design of
+ *         lista-new-contracts/src/rwa/RWAAdapter.sol.
+ *
+ * Both the flex and locked pools forward user deposits straight to this adapter,
+ * so all fund logic lives here:
+ *  - deploy idle funds to Surfin (off-chain) by transferring straight to Surfin's
+ *    receiving wallet, not split by product — one combined transfer;
+ *  - enforce a single on-chain hard floor (3% of both pools' live book) that is
+ *    never paid out and doubles as the interest reserve; the 15% buffer target is
+ *    maintained off-chain;
+ *  - repay the pools' batch queues and book interest, bounded by that floor.
+ */
+contract SurfinAdapter is AccessControlEnumerableUpgradeable, PausableUpgradeable, UUPSUpgradeable {
+  using SafeERC20 for IERC20;
+  using Math for uint256;
+
+  /* VARIABLES */
+  // flex (demand) pool
+  address public flexPool;
+  // locked (term) pool
+  address public lockedPool;
+  // Surfin receiving wallet (off-chain custody/multisig that funds are deployed to)
+  address public surfinWallet;
+  // interest distributor (cumulative Merkle interest payouts)
+  address public interestDistributor;
+
+  // accrued Lista profit fee earmark; withdrawable by manager only
+  uint256 public accruedFee;
+  // book value currently deployed to Surfin
+  uint256 public deployedToSurfin;
+
+  // single hard-floor rate over both pools' live book, 1e18 (e.g. 0.03e18 = 3%).
+  // The 15% buffer target is maintained off-chain; only the hard floor is enforced
+  // on-chain (also doubles as the interest reserve).
+  uint256 public floorRate;
+
+  // profit fee receiver (accruedFee is paid out here by claimFee)
+  address public feeReceiver;
+
+  /* CONSTANTS */
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+  bytes32 public constant BOT = keccak256("BOT");
+  bytes32 public constant PAUSER = keccak256("PAUSER");
+  uint256 public constant PRECISION = 1e18;
+
+  /* IMMUTABLE */
+  // asset token (USDT)
+  address public immutable asset;
+
+  /* EVENTS */
+  event DeployToSurfin(uint256 amount);
+  event FinishFlexWithdraw(uint256 amount);
+  event FinishLockedWithdraw(uint256 amount);
+  event FundInterest(uint256 amount);
+  event ClaimFee(address receiver, uint256 amount);
+  event SettleRecall(uint256 recalledAmount, uint256 lockedCoverAmount, uint256 feeAmount, uint256 deployedBookValue);
+  event SetFloorRate(uint256 floorRate);
+  event SetSurfinWallet(address surfinWallet);
+  event SetInterestDistributor(address interestDistributor);
+  event SetFeeReceiver(address feeReceiver);
+  event EmergencyWithdraw(address token, uint256 amount);
+
+  /* CONSTRUCTOR */
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  /// @param _asset The address of the asset token (USDT).
+  constructor(address _asset) {
+    require(_asset != address(0), "asset is zero address");
+    _disableInitializers();
+    asset = _asset;
+  }
+
+  /* INITIALIZER */
+  function initialize(
+    address _admin,
+    address _manager,
+    address _pauser,
+    address _bot,
+    address _flexPool,
+    address _lockedPool,
+    address _surfinWallet
+  ) external initializer {
+    require(_admin != address(0), "admin is zero address");
+    require(_manager != address(0), "manager is zero address");
+    require(_pauser != address(0), "pauser is zero address");
+    require(_bot != address(0), "bot is zero address");
+    require(_flexPool != address(0), "flexPool is zero address");
+    require(_lockedPool != address(0), "lockedPool is zero address");
+    require(_surfinWallet != address(0), "surfinWallet is zero address");
+
+    __AccessControlEnumerable_init();
+    __Pausable_init();
+
+    _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    _grantRole(MANAGER, _manager);
+    _grantRole(PAUSER, _pauser);
+    _grantRole(BOT, _bot);
+
+    flexPool = _flexPool;
+    lockedPool = _lockedPool;
+    surfinWallet = _surfinWallet;
+
+    // default hard floor: 3% of both pools' live book
+    floorRate = 3 * 1e16;
+  }
+
+  /* DEPLOY TO SURFIN */
+  /**
+   * @dev deploy idle funds to Surfin by transferring straight to Surfin's receiving
+   *      wallet. Not split by product. Sensitive outflow, so gated to MANAGER
+   *      (multisig). Blocked while paused and capped by the deployable amount.
+   * @param amount the amount of asset to deploy
+   */
+  function deployToSurfin(uint256 amount) external onlyRole(MANAGER) whenNotPaused {
+    require(amount > 0, "amount is zero");
+    require(amount <= maxDeployToSurfin(), "exceeds deployable");
+
+    deployedToSurfin += amount;
+
+    IERC20(asset).safeTransfer(surfinWallet, amount);
+
+    emit DeployToSurfin(amount);
+  }
+
+  /**
+   * @dev weekly recall settlement (multisig). The manager transfers the recalled
+   *      USDT into the adapter and, in one call: resets the Surfin book value,
+   *      sets the platform fee earmark, covers the locked withdrawal queue, and
+   *      leaves the remainder as buffer. Replaces repayFromSurfin + bookFee.
+   *
+   *      recalledAmount must cover everything this call consumes (locked cover +
+   *      fee); the remainder (recalledAmount - lockedCoverAmount - feeAmount)
+   *      stays on the adapter as buffer. deployedBookValue is an absolute reset,
+   *      bidirectional: a recall lowers it, while 80% of Surfin interest rolling
+   *      into principal raises it.
+   * @param recalledAmount the recall USDT the manager transfers in (must approve first)
+   * @param lockedCoverAmount amount to push into the locked pool's batch queue
+   * @param feeAmount platform fee to earmark (Lista's share)
+   * @param deployedBookValue the new absolute Surfin deployed book value
+   */
+  function settleRecall(
+    uint256 recalledAmount,
+    uint256 lockedCoverAmount,
+    uint256 feeAmount,
+    uint256 deployedBookValue
+  ) external onlyRole(MANAGER) whenNotPaused {
+    require(recalledAmount >= lockedCoverAmount + feeAmount, "recall insufficient");
+    IERC20(asset).safeTransferFrom(msg.sender, address(this), recalledAmount);
+    deployedToSurfin = deployedBookValue; // absolute reset (bidirectional)
+    accruedFee += feeAmount; // fee earmark set by multisig
+    if (lockedCoverAmount > 0) {
+      _finishLockedWithdraw(lockedCoverAmount);
+    }
+    emit SettleRecall(recalledAmount, lockedCoverAmount, feeAmount, deployedBookValue);
+  }
+
+  /* REPAY POOL QUEUES */
+  /**
+   * @dev repay the flex pool's batch queue from idle funds. `amount` may be 0 to
+   *      only advance batches.
+   */
+  function finishFlexWithdraw(uint256 amount) external onlyRole(BOT) {
+    require(amount <= _availableForWithdraw(), "exceeds available");
+    if (amount > 0) {
+      IERC20(asset).safeIncreaseAllowance(flexPool, amount);
+    }
+    ICreditFundPool(flexPool).finishWithdraw(amount);
+    emit FinishFlexWithdraw(amount);
+  }
+
+  /**
+   * @dev repay the locked pool's batch queue (early-redeem + matured) from idle
+   *      funds. BOT-callable so, if the weekly recall has not landed on time, the
+   *      bot can still cover locked withdrawals out of the buffer pool. Bounded by
+   *      the reserve guard (fee + hard floor) in _finishLockedWithdraw, which
+   *      settleRecall also reuses.
+   */
+  function finishLockedWithdraw(uint256 amount) external onlyRole(BOT) {
+    _finishLockedWithdraw(amount);
+  }
+
+  /* FUND INTEREST */
+  /**
+   * @dev fund the interest distributor from idle funds. Interest for both flex and
+   *      locked users is paid off-pool through the cumulative Merkle distributor,
+   *      so the adapter only tops it up; per-user amounts live in the merkle root.
+   * @param amount the interest amount to fund
+   */
+  function fundInterest(uint256 amount) external onlyRole(MANAGER) {
+    require(interestDistributor != address(0), "interestDistributor not set");
+    require(amount > 0, "amount is zero");
+    // interest may consume the hard floor (floor doubles as the interest reserve);
+    // only the fee earmark is protected. A drained floor blocks flex withdrawals
+    // via _availableForWithdraw until the next weekly recall tops it back up.
+    require(amount <= freeIdle(), "insufficient idle");
+    IERC20(asset).safeIncreaseAllowance(interestDistributor, amount);
+    IInterestDistributor(interestDistributor).notifyReward(amount);
+    emit FundInterest(amount);
+  }
+
+  /* PROFIT FEE (Lista share) */
+  /**
+   * @dev claim accrued fee to the fee receiver. BOT-callable so fee collection can
+   *      be automated; funds can only move to the manager-set feeReceiver.
+   */
+  function claimFee(uint256 amount) external onlyRole(BOT) {
+    require(feeReceiver != address(0), "feeReceiver is zero");
+    require(amount > 0 && amount <= accruedFee, "invalid amount");
+    accruedFee -= amount;
+    IERC20(asset).safeTransfer(feeReceiver, amount);
+    emit ClaimFee(feeReceiver, amount);
+  }
+
+  /* VIEWS */
+  /**
+   * @dev instantly-available liquidity held by the adapter (raw asset balance).
+   */
+  function idleBalance() public view returns (uint256) {
+    return IERC20(asset).balanceOf(address(this));
+  }
+
+  /**
+   * @dev freely usable idle funds after excluding the fee earmark.
+   */
+  function freeIdle() public view returns (uint256) {
+    uint256 bal = idleBalance();
+    return bal > accruedFee ? bal - accruedFee : 0;
+  }
+
+  /**
+   * @dev floor base: both pools' live principal book, restored to the pre-burn
+   *      level by adding totalPendingWithdraw (principal is decremented at request
+   *      time, but the cash only leaves the adapter at finishWithdraw).
+   */
+  function _floorBase() internal view returns (uint256) {
+    return
+      ICreditFundPool(flexPool).totalPrincipal() +
+      ICreditFundPool(flexPool).totalPendingWithdraw() +
+      ICreditFundPool(lockedPool).totalPrincipal() +
+      ICreditFundPool(lockedPool).totalPendingWithdraw();
+  }
+
+  /**
+   * @dev on-chain hard floor (3% of the floor base). Never paid out for flex/locked
+   *      withdrawals; doubles as the interest reserve.
+   */
+  function hardFloor() public view returns (uint256) {
+    return (_floorBase() * floorRate) / PRECISION;
+  }
+
+  /**
+   * @dev max amount deployable to Surfin: everything above the hard floor (free idle
+   *      already excludes the fee earmark). The 15% buffer / pending-withdrawal
+   *      liquidity is maintained off-chain by the multisig when sizing the deploy;
+   *      on-chain only the hard floor is reserved.
+   */
+  function maxDeployToSurfin() public view returns (uint256) {
+    uint256 free = freeIdle();
+    uint256 floor = hardFloor();
+    return free > floor ? free - floor : 0;
+  }
+
+  /**
+   * @dev informational: instantly withdrawable amount payable to users, i.e. cash
+   *      above the protected reserve (fee + hard floor).
+   */
+  function instantWithdrawable() external view returns (uint256) {
+    return _availableForWithdraw();
+  }
+
+  /* MANAGER FUNCTIONS */
+  /// @dev emergency stop for outbound flows (deploy to Surfin)
+  function pause() external onlyRole(PAUSER) {
+    _pause();
+  }
+
+  /// @dev lift the emergency stop
+  function unpause() external onlyRole(MANAGER) {
+    _unpause();
+  }
+
+  function setFloorRate(uint256 _floorRate) external onlyRole(MANAGER) {
+    require(_floorRate <= PRECISION, "invalid floor rate");
+    floorRate = _floorRate;
+    emit SetFloorRate(_floorRate);
+  }
+
+  function setSurfinWallet(address _surfinWallet) external onlyRole(MANAGER) {
+    require(_surfinWallet != address(0), "surfinWallet is zero address");
+    surfinWallet = _surfinWallet;
+    emit SetSurfinWallet(_surfinWallet);
+  }
+
+  function setInterestDistributor(address _interestDistributor) external onlyRole(MANAGER) {
+    require(_interestDistributor != address(0), "interestDistributor is zero address");
+    interestDistributor = _interestDistributor;
+    emit SetInterestDistributor(_interestDistributor);
+  }
+
+  function setFeeReceiver(address _feeReceiver) external onlyRole(MANAGER) {
+    require(_feeReceiver != address(0), "feeReceiver is zero");
+    feeReceiver = _feeReceiver;
+    emit SetFeeReceiver(_feeReceiver);
+  }
+
+  /**
+   * @dev emergency token rescue by admin.
+   */
+  function emergencyWithdraw(address token, uint256 amount, address receiver) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(amount > 0, "amount is zero");
+    require(receiver != address(0), "receiver is zero address");
+    IERC20(token).safeTransfer(receiver, amount);
+    emit EmergencyWithdraw(token, amount);
+  }
+
+  /* INTERNAL FUNCTIONS */
+  /**
+   * @dev cash payable for flex/locked withdrawals: on-adapter balance minus the
+   *      protected reserve (fee earmark + hard floor).
+   */
+  function _availableForWithdraw() internal view returns (uint256) {
+    uint256 cash = idleBalance();
+    uint256 protectedAmt = accruedFee + hardFloor();
+    return cash > protectedAmt ? cash - protectedAmt : 0;
+  }
+
+  /**
+   * @dev shared locked-queue repay path, bounded by the reserve guard. Reused by
+   *      finishLockedWithdraw (BOT) and settleRecall.
+   */
+  function _finishLockedWithdraw(uint256 amount) internal {
+    require(amount <= _availableForWithdraw(), "exceeds available");
+    if (amount > 0) {
+      IERC20(asset).safeIncreaseAllowance(lockedPool, amount);
+    }
+    ICreditFundPool(lockedPool).finishWithdraw(amount);
+    emit FinishLockedWithdraw(amount);
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/src/surfin/SurfinAdapter.sol
+++ b/src/surfin/SurfinAdapter.sol
@@ -6,7 +6,6 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgrade
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { ICreditFundPool } from "./interface/ICreditFundPool.sol";
 import { IInterestDistributor } from "./interface/IInterestDistributor.sol";
@@ -27,7 +26,6 @@ import { IInterestDistributor } from "./interface/IInterestDistributor.sol";
  */
 contract SurfinAdapter is AccessControlEnumerableUpgradeable, PausableUpgradeable, UUPSUpgradeable {
   using SafeERC20 for IERC20;
-  using Math for uint256;
 
   /* VARIABLES */
   // flex (demand) pool
@@ -116,6 +114,7 @@ contract SurfinAdapter is AccessControlEnumerableUpgradeable, PausableUpgradeabl
 
     // default hard floor: 3% of both pools' live book
     floorRate = 3 * 1e16;
+    emit SetFloorRate(floorRate);
   }
 
   /* DEPLOY TO SURFIN */
@@ -352,4 +351,6 @@ contract SurfinAdapter is AccessControlEnumerableUpgradeable, PausableUpgradeabl
   }
 
   function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+  uint256[50] private __gap;
 }

--- a/src/surfin/interface/ICreditFundPool.sol
+++ b/src/surfin/interface/ICreditFundPool.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Interface the SurfinAdapter uses to drive an EarnPool (flex or locked).
+ *
+ * Funds always live in the adapter; the pool only keeps accounting. The adapter
+ * therefore is the only caller of `finishWithdraw`, which repays the batch queue.
+ * Interest is not booked on the pool: it is distributed off-pool through the
+ * cumulative Merkle `InterestDistributor`.
+ */
+interface ICreditFundPool {
+  /// @dev asset token of the pool (USDT)
+  function asset() external view returns (address);
+
+  /// @dev total user principal booked in the pool (1:1 with LP for flex, sum of positions for locked)
+  function totalPrincipal() external view returns (uint256);
+
+  /// @dev principal that has been requested for withdraw but not yet claimed
+  function totalPendingWithdraw() external view returns (uint256);
+
+  /// @dev repay the batch withdraw queue; adapter transfers `amount` in first
+  function finishWithdraw(uint256 amount) external;
+}

--- a/src/surfin/interface/IInterestDistributor.sol
+++ b/src/surfin/interface/IInterestDistributor.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Interface the SurfinAdapter uses to fund the InterestDistributor.
+ *
+ * Interest is distributed to users through a cumulative Merkle tree held by the
+ * InterestDistributor. Funds live on the adapter, so the adapter tops the
+ * distributor up via `notifyReward` (guarded by the FUNDER role) before a new
+ * root is published; users then claim their cumulative interest directly from
+ * the distributor.
+ */
+interface IInterestDistributor {
+  /// @dev fund the distributor with interest to distribute; pulls `amount` of the
+  ///      interest token from the caller, who must hold the FUNDER role
+  function notifyReward(uint256 amount) external;
+}

--- a/test/surfin/FlexEarnPool.t.sol
+++ b/test/surfin/FlexEarnPool.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./SurfinTestBase.sol";
+
+/**
+ * Test group 3 / module A — FlexEarnPool (demand product).
+ *
+ * Expectations are derived from the PRD, not from the implementation:
+ *  - A1 face value: 1 LP == 1 USDT, funds custody at the adapter (§4.1)
+ *  - A2 two-step withdraw + per-address daily submit cap (§4.5, §14.4)
+ *  - A3 cancel does NOT refund the daily quota (§4.5)
+ *  - A4 cancel only unlocks the LP, moves no cash; confirmed requests can't cancel (§4.5)
+ */
+contract FlexEarnPoolTest is SurfinTestBase {
+  /* ----------------------------- A1: deposit ----------------------------- */
+
+  function test_A1_depositMints1to1AndForwardsToAdapter() public {
+    _depositFlex(alice, 10_000 ether);
+
+    assertEq(flex.balanceOf(alice), 10_000 ether, "1 LP == 1 USDT");
+    assertEq(flex.totalSupply(), 10_000 ether, "supply tracks principal");
+    assertEq(usdt.balanceOf(address(adapter)), 10_000 ether, "funds custody at the adapter");
+    assertEq(usdt.balanceOf(address(flex)), 0, "pool holds accounting only");
+  }
+
+  function test_A1_depositBelowMinimumReverts() public {
+    vm.prank(manager);
+    flex.setMinDeposit(1_000 ether);
+
+    usdt.mint(alice, 500 ether);
+    vm.startPrank(alice);
+    usdt.approve(address(flex), 500 ether);
+    vm.expectRevert("deposit below minimum");
+    flex.deposit(500 ether, alice);
+    vm.stopPrank();
+  }
+
+  function test_A1_depositZeroReverts() public {
+    vm.prank(alice);
+    vm.expectRevert("amount is zero");
+    flex.deposit(0, alice);
+  }
+
+  /* ------------------------- A2: two-step withdraw ------------------------- */
+
+  function test_A2_withdrawTwoStepFlow() public {
+    _depositFlex(alice, 100_000 ether);
+
+    // step 1 — request: burns LP, enqueues, no cash moves to the user yet
+    vm.prank(alice);
+    flex.requestWithdraw(40_000 ether);
+    assertEq(flex.balanceOf(alice), 60_000 ether, "LP burned on request");
+    assertEq(flex.totalPendingWithdraw(), 40_000 ether, "request enqueued");
+    assertEq(usdt.balanceOf(alice), 0, "no payout at request time");
+
+    // step 2 — BOT funds the batch: cash lands in the pool, batch confirmed
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(40_000 ether);
+    assertEq(usdt.balanceOf(address(flex)), 40_000 ether, "cash sits in the pool awaiting claim");
+    assertEq(flex.confirmedBatchId(), 1, "batch confirmed");
+    assertEq(usdt.balanceOf(alice), 0, "still not in the wallet");
+
+    // step 3 — claim: cash reaches the user wallet
+    vm.prank(alice);
+    flex.claimWithdraw(alice, 0);
+    assertEq(usdt.balanceOf(alice), 40_000 ether, "claimed to wallet");
+    assertEq(flex.totalPendingWithdraw(), 0, "pending cleared only on claim");
+  }
+
+  function test_A2_dailyLimitBoundary() public {
+    vm.prank(manager);
+    flex.setDailyLimit(200_000 ether);
+    _depositFlex(alice, 500_000 ether);
+
+    // exactly at the cap passes
+    vm.prank(alice);
+    flex.requestWithdraw(200_000 ether);
+
+    // one wei over the same-day cap reverts
+    vm.prank(alice);
+    vm.expectRevert("exceeds daily limit");
+    flex.requestWithdraw(1);
+  }
+
+  function test_A2_dailyLimitResetsNextUtcDay() public {
+    vm.prank(manager);
+    flex.setDailyLimit(200_000 ether);
+    _depositFlex(alice, 500_000 ether);
+
+    vm.prank(alice);
+    flex.requestWithdraw(200_000 ether); // day D: cap consumed
+
+    vm.warp(block.timestamp + 1 days); // cross into the next UTC day
+
+    vm.prank(alice);
+    flex.requestWithdraw(200_000 ether); // counter reset -> passes
+    assertEq(flex.balanceOf(alice), 100_000 ether, "both days' requests cleared");
+  }
+
+  /* --------------------- A3: cancel does not refund quota --------------------- */
+
+  function test_A3_cancelDoesNotRefundDailyQuota() public {
+    vm.prank(manager);
+    flex.setDailyLimit(200_000 ether);
+    _depositFlex(alice, 500_000 ether);
+
+    vm.prank(alice);
+    flex.requestWithdraw(100_000 ether); // 100k of today's cap consumed
+
+    vm.prank(alice);
+    flex.cancelWithdraw(0); // restores LP, but the daily quota is NOT given back
+
+    // 100k already counted + 150k new = 250k > 200k cap -> revert
+    vm.prank(alice);
+    vm.expectRevert("exceeds daily limit");
+    flex.requestWithdraw(150_000 ether);
+  }
+
+  /* ----------------------- A4: cancel semantics ----------------------- */
+
+  function test_A4_cancelRestoresLpAndMovesNoCash() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(alice);
+    flex.requestWithdraw(40_000 ether);
+
+    uint256 adapterBal = usdt.balanceOf(address(adapter));
+    vm.prank(alice);
+    flex.cancelWithdraw(0);
+
+    assertEq(flex.balanceOf(alice), 100_000 ether, "LP fully restored");
+    assertEq(flex.totalPendingWithdraw(), 0, "pending removed");
+    assertEq(usdt.balanceOf(address(adapter)), adapterBal, "cancel moves no USDT");
+    assertEq(usdt.balanceOf(alice), 0, "user receives nothing on cancel");
+  }
+
+  function test_A4_cancelConfirmedRequestReverts() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(alice);
+    flex.requestWithdraw(40_000 ether);
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(40_000 ether); // batch 1 confirmed
+
+    vm.prank(alice);
+    vm.expectRevert("already confirmed");
+    flex.cancelWithdraw(0);
+  }
+
+  function test_A4_claimBeforeConfirmationReverts() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(alice);
+    flex.requestWithdraw(40_000 ether); // enqueued but unfunded
+
+    vm.prank(alice);
+    vm.expectRevert("not able to claim yet");
+    flex.claimWithdraw(alice, 0);
+  }
+}

--- a/test/surfin/FlexEarnPool.t.sol
+++ b/test/surfin/FlexEarnPool.t.sol
@@ -63,7 +63,7 @@ contract FlexEarnPoolTest is SurfinTestBase {
 
     // step 3 — claim: cash reaches the user wallet
     vm.prank(alice);
-    flex.claimWithdraw(alice, 0);
+    flex.claimWithdraw(alice, 0, 40_000 ether);
     assertEq(usdt.balanceOf(alice), 40_000 ether, "claimed to wallet");
     assertEq(flex.totalPendingWithdraw(), 0, "pending cleared only on claim");
   }
@@ -109,7 +109,7 @@ contract FlexEarnPoolTest is SurfinTestBase {
     flex.requestWithdraw(100_000 ether); // 100k of today's cap consumed
 
     vm.prank(alice);
-    flex.cancelWithdraw(0); // restores LP, but the daily quota is NOT given back
+    flex.cancelWithdraw(0, 100_000 ether); // restores LP, but the daily quota is NOT given back
 
     // 100k already counted + 150k new = 250k > 200k cap -> revert
     vm.prank(alice);
@@ -126,7 +126,7 @@ contract FlexEarnPoolTest is SurfinTestBase {
 
     uint256 adapterBal = usdt.balanceOf(address(adapter));
     vm.prank(alice);
-    flex.cancelWithdraw(0);
+    flex.cancelWithdraw(0, 40_000 ether);
 
     assertEq(flex.balanceOf(alice), 100_000 ether, "LP fully restored");
     assertEq(flex.totalPendingWithdraw(), 0, "pending removed");
@@ -143,7 +143,7 @@ contract FlexEarnPoolTest is SurfinTestBase {
 
     vm.prank(alice);
     vm.expectRevert("already confirmed");
-    flex.cancelWithdraw(0);
+    flex.cancelWithdraw(0, 40_000 ether);
   }
 
   function test_A4_claimBeforeConfirmationReverts() public {
@@ -153,6 +153,6 @@ contract FlexEarnPoolTest is SurfinTestBase {
 
     vm.prank(alice);
     vm.expectRevert("not able to claim yet");
-    flex.claimWithdraw(alice, 0);
+    flex.claimWithdraw(alice, 0, 40_000 ether);
   }
 }

--- a/test/surfin/InterestDistributor.t.sol
+++ b/test/surfin/InterestDistributor.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./SurfinTestBase.sol";
+
+/**
+ * Test group 3 / module D — InterestDistributor (cumulative Merkle interest).
+ *
+ * PRD-derived expectations:
+ *  - D1 principal/interest are separate; interest is claimed cumulatively — each
+ *       claim pays totalAmount - alreadyClaimed, monotonic, no double pay (§4.2)
+ *  - D2 root updates are two-step and time-locked (revocable before going live)
+ *  - D3 leaves are bound to (chainid, this, selector) so proofs can't be replayed
+ *       across chains or contracts (§4.1 dual-chain isolation)
+ *
+ * Claim math is what is under test here, so the distributor is funded directly;
+ * the notifyReward funding path is covered in module C (fundInterest).
+ */
+contract InterestDistributorTest is SurfinTestBase {
+  bytes32[] internal emptyProof;
+
+  /* ------------------------- D1: cumulative claims ------------------------- */
+
+  function test_D1_cumulativeClaimPaysOnlyTheDelta() public {
+    usdt.mint(address(distributor), 2_000 ether);
+
+    _publishRoot(_leaf(alice, 1_000 ether)); // cumulative total 1,000
+    distributor.claim(alice, 1_000 ether, emptyProof);
+    assertEq(usdt.balanceOf(alice), 1_000 ether, "first claim pays the full 1,000");
+    assertEq(distributor.claimed(alice), 1_000 ether);
+
+    _publishRoot(_leaf(alice, 1_500 ether)); // cumulative total 1,500
+    distributor.claim(alice, 1_500 ether, emptyProof);
+    assertEq(usdt.balanceOf(alice), 1_500 ether, "second claim pays only the 500 delta");
+    assertEq(distributor.claimed(alice), 1_500 ether, "claimed is monotonic");
+  }
+
+  function test_D1_repeatClaimSameRootReverts() public {
+    usdt.mint(address(distributor), 1_000 ether);
+    _publishRoot(_leaf(alice, 1_000 ether));
+
+    distributor.claim(alice, 1_000 ether, emptyProof);
+    vm.expectRevert("Invalid total amount"); // nothing new to claim
+    distributor.claim(alice, 1_000 ether, emptyProof);
+  }
+
+  function test_D1_batchClaimTwoLeaves() public {
+    usdt.mint(address(distributor), 3_000 ether);
+
+    bytes32 leafA = _leaf(alice, 1_000 ether);
+    bytes32 leafB = _leaf(bob, 2_000 ether);
+    bytes32 root = leafA < leafB
+      ? keccak256(abi.encodePacked(leafA, leafB))
+      : keccak256(abi.encodePacked(leafB, leafA));
+    _publishRoot(root);
+
+    address[] memory accts = new address[](2);
+    uint256[] memory amts = new uint256[](2);
+    bytes32[][] memory proofs = new bytes32[][](2);
+    accts[0] = alice;
+    amts[0] = 1_000 ether;
+    proofs[0] = new bytes32[](1);
+    proofs[0][0] = leafB;
+    accts[1] = bob;
+    amts[1] = 2_000 ether;
+    proofs[1] = new bytes32[](1);
+    proofs[1][0] = leafA;
+
+    distributor.batchClaim(accts, amts, proofs);
+    assertEq(usdt.balanceOf(alice), 1_000 ether);
+    assertEq(usdt.balanceOf(bob), 2_000 ether);
+  }
+
+  function test_D1_invalidProofReverts() public {
+    usdt.mint(address(distributor), 1_000 ether);
+    _publishRoot(_leaf(alice, 1_000 ether));
+
+    bytes32[] memory badProof = new bytes32[](1);
+    badProof[0] = bytes32(uint256(0x1234));
+    vm.expectRevert("Invalid proof");
+    distributor.claim(alice, 1_000 ether, badProof);
+  }
+
+  /* ------------------------ D2: two-step timelock ------------------------ */
+
+  function test_D2_acceptBeforeWaitingPeriodReverts() public {
+    vm.prank(bot);
+    distributor.setPendingMerkleRoot(_leaf(alice, 1_000 ether));
+
+    vm.prank(bot);
+    vm.expectRevert("Not ready to accept");
+    distributor.acceptMerkleRoot();
+  }
+
+  function test_D2_acceptAfterWaitingPeriodSucceeds() public {
+    bytes32 root = _leaf(alice, 1_000 ether);
+    vm.prank(bot);
+    distributor.setPendingMerkleRoot(root);
+
+    vm.warp(block.timestamp + distributor.waitingPeriod());
+    vm.prank(bot);
+    distributor.acceptMerkleRoot();
+    assertEq(distributor.merkleRoot(), root, "root goes live after the delay");
+  }
+
+  function test_D2_setPendingRootOnlyBot() public {
+    vm.prank(manager);
+    vm.expectRevert();
+    distributor.setPendingMerkleRoot(_leaf(alice, 1_000 ether));
+  }
+
+  function test_D2_revokePendingRootBlocksAccept() public {
+    bytes32 root = _leaf(alice, 1_000 ether);
+    vm.prank(bot);
+    distributor.setPendingMerkleRoot(root);
+
+    vm.prank(manager);
+    distributor.revokePendingMerkleRoot();
+    assertEq(distributor.pendingMerkleRoot(), bytes32(0), "pending cleared");
+
+    vm.warp(block.timestamp + distributor.waitingPeriod());
+    vm.prank(bot);
+    vm.expectRevert("Invalid pending merkle root");
+    distributor.acceptMerkleRoot();
+  }
+
+  /* ------------------------ D3: replay protection ------------------------ */
+
+  function test_D3_leafFromForeignChainIdReplayFails() public {
+    usdt.mint(address(distributor), 1_000 ether);
+    // a leaf minted for chainid 999 — claim recomputes with block.chainid, so it won't match
+    bytes32 foreignLeaf = keccak256(
+      abi.encode(uint256(999), address(distributor), distributor.claim.selector, alice, uint256(1_000 ether))
+    );
+    _publishRoot(foreignLeaf);
+
+    vm.expectRevert("Invalid proof");
+    distributor.claim(alice, 1_000 ether, emptyProof);
+  }
+
+  function test_D3_leafBoundToForeignContractReplayFails() public {
+    usdt.mint(address(distributor), 1_000 ether);
+    // a leaf bound to a different distributor address
+    bytes32 foreignLeaf = keccak256(
+      abi.encode(block.chainid, address(0xBEEF), distributor.claim.selector, alice, uint256(1_000 ether))
+    );
+    _publishRoot(foreignLeaf);
+
+    vm.expectRevert("Invalid proof");
+    distributor.claim(alice, 1_000 ether, emptyProof);
+  }
+}

--- a/test/surfin/LockedEarnPool.t.sol
+++ b/test/surfin/LockedEarnPool.t.sol
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./SurfinTestBase.sol";
+import "../../src/surfin/CreditFundBase.sol";
+
+/**
+ * Test group 3 / module B — LockedEarnPool (term product).
+ *
+ * PRD-derived expectations:
+ *  - B1 early-redeem penalty is computed on-chain (§4.4); flat rate on redeemed
+ *       principal inside the 30-day window, full principal past it; partial allowed
+ *  - B2 early-redeem is irreversible — no cancel entrypoint (§4.4)
+ *  - B3 the locked daily submit counter is independent from flex (§14.4)
+ *  - B4 matured withdrawal has no penalty and is exempt from the daily cap (§4.3)
+ *  - B5 auto-renew rolls principal only and is capped at one term (§4.3)
+ *  - B6 auto-renew toggle is locked inside the T-window before maturity (§4.3)
+ *  - B7 one-click reinvest rolls a funded payout into a new cohort (§4.3)
+ *  - B8 setCohort maturity guardrail bounds the settlement alignment (§4.3)
+ *
+ * NOTE: the contract's early-redeem model is a flat penalty on principal, which is
+ * simpler than the PRD's base-interest-offset model (see SurfinConflict CONFLICT-2).
+ * These tests pin the contract's actual flat-penalty math.
+ */
+contract LockedEarnPoolTest is SurfinTestBase {
+  uint256 constant T0 = 1_000_000;
+
+  function _openCohort(uint256 id) internal {
+    _setCohort(id, 90, block.timestamp + 1 days, block.timestamp + 91 days, true);
+  }
+
+  /* ----------------------------- B1: early redeem ----------------------------- */
+
+  function test_B1_earlyRedeemFlatPenaltyWithinWindow() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, false);
+
+    vm.warp(block.timestamp + 10 days); // still inside the 30-day penalty window
+    uint256 payout = locked.previewEarlyRedeem(alice, 0, 50_000 ether);
+    assertEq(payout, 49_600 ether, "flat 0.8% penalty (50,000 * 0.008 = 400)");
+
+    vm.prank(alice);
+    locked.requestEarlyRedeem(0, 50_000 ether);
+
+    assertEq(locked.totalPendingWithdraw(), 49_600 ether, "penalized payout queued");
+    LockedEarnPool.Position[] memory pos = locked.getUserPositions(alice);
+    assertEq(pos[0].principal, 0, "principal fully redeemed");
+    assertTrue(pos[0].closed, "position closed");
+    assertEq(locked.totalPrincipalAmount(), 0, "book principal removed");
+  }
+
+  function test_B1_earlyRedeemNoPenaltyPastWindow() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, false);
+
+    vm.warp(block.timestamp + 30 days); // exactly at the window edge -> no penalty
+    uint256 payout = locked.previewEarlyRedeem(alice, 0, 50_000 ether);
+    assertEq(payout, 50_000 ether, "full principal returned at/after the window edge");
+  }
+
+  function test_B1_partialEarlyRedeemSplitsPosition() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, false);
+
+    vm.warp(block.timestamp + 10 days);
+    vm.prank(alice);
+    locked.requestEarlyRedeem(0, 20_000 ether); // partial
+
+    LockedEarnPool.Position[] memory pos = locked.getUserPositions(alice);
+    assertEq(pos[0].principal, 30_000 ether, "remaining principal stays in the position");
+    assertFalse(pos[0].closed, "position still open");
+    assertEq(locked.totalPrincipalAmount(), 30_000 ether, "book reduced by redeemed part only");
+    assertEq(locked.totalPendingWithdraw(), 19_840 ether, "20,000 * 0.992 = 19,840 queued");
+  }
+
+  function test_B1_earlyRedeemAfterMaturityReverts() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, false);
+
+    vm.warp(block.timestamp + 92 days); // past maturity
+    vm.prank(alice);
+    vm.expectRevert("already matured");
+    locked.requestEarlyRedeem(0, 50_000 ether);
+  }
+
+  /* --------------------- B2: early redeem is irreversible --------------------- */
+
+  function test_B2_earlyRedeemIsIrreversibleNoCancelEntrypoint() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, false);
+
+    vm.warp(block.timestamp + 10 days);
+    vm.prank(alice);
+    locked.requestEarlyRedeem(0, 50_000 ether);
+
+    // Unlike FlexEarnPool, LockedEarnPool exposes no cancelWithdraw. The position is
+    // closed and the queued payout can only be consumed via claimWithdraw after
+    // funding — there is no path to reopen the position or reclaim the principal.
+    LockedEarnPool.Position[] memory pos = locked.getUserPositions(alice);
+    assertTrue(pos[0].closed, "position permanently closed");
+    CreditFundBase.WithdrawalRequest[] memory reqs = locked.getUserWithdrawalRequests(alice);
+    assertEq(reqs.length, 1, "single queued payout, claim-only exit");
+  }
+
+  /* -------------------- B3: locked daily cap independent -------------------- */
+
+  function test_B3_lockedDailyLimitIndependentFromFlex() public {
+    vm.warp(T0);
+    vm.startPrank(manager);
+    flex.setDailyLimit(200_000 ether);
+    locked.setDailyLimit(200_000 ether);
+    locked.setPenaltyRate(0); // isolate daily-limit behavior from penalty math
+    vm.stopPrank();
+    _openCohort(1);
+
+    // same day: flex fills its own 200k cap
+    _depositFlex(alice, 200_000 ether);
+    vm.prank(alice);
+    flex.requestWithdraw(200_000 ether);
+
+    // same day: a 200k locked early-redeem must still pass on its own counter
+    _depositLocked(alice, 1, 200_000 ether, false);
+    vm.prank(alice);
+    locked.requestEarlyRedeem(0, 200_000 ether);
+    assertEq(locked.totalPendingWithdraw(), 200_000 ether, "locked daily counter is separate from flex");
+  }
+
+  /* ---------------------- B4: matured withdrawal ---------------------- */
+
+  function test_B4_maturityWithdrawNoPenaltyExemptFromDailyCap() public {
+    vm.warp(T0);
+    vm.prank(manager);
+    locked.setDailyLimit(200_000 ether); // cap well below the position size
+    _openCohort(1);
+    _depositLocked(alice, 1, 500_000 ether, false);
+
+    vm.warp(block.timestamp + 92 days); // matured
+    vm.prank(alice);
+    locked.requestMaturityWithdraw(0); // 500k > 200k cap, but maturity is exempt
+
+    assertEq(locked.totalPendingWithdraw(), 500_000 ether, "full principal queued, no penalty, no cap");
+    LockedEarnPool.Position[] memory pos = locked.getUserPositions(alice);
+    assertTrue(pos[0].closed);
+  }
+
+  function test_B4_maturityWithdrawBeforeMaturityReverts() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, false);
+
+    vm.prank(alice);
+    vm.expectRevert("not matured");
+    locked.requestMaturityWithdraw(0);
+  }
+
+  function test_B4_maturityWithdrawWhileAutoRenewReverts() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, true); // auto-renew ON
+
+    vm.warp(block.timestamp + 92 days);
+    vm.prank(alice);
+    vm.expectRevert("auto renew on");
+    locked.requestMaturityWithdraw(0);
+  }
+
+  function test_B4_batchMaturityWithdrawIsBotOnly() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, false);
+    vm.warp(block.timestamp + 92 days);
+
+    address[] memory users = new address[](1);
+    uint256[] memory posIds = new uint256[](1);
+    users[0] = alice;
+    posIds[0] = 0;
+
+    vm.prank(manager); // manager lacks BOT
+    vm.expectRevert();
+    locked.batchRequestMaturityWithdraw(users, posIds);
+
+    vm.prank(bot);
+    locked.batchRequestMaturityWithdraw(users, posIds);
+    assertEq(locked.totalPendingWithdraw(), 50_000 ether, "BOT queued the matured principal");
+  }
+
+  /* ------------------------- B5: auto-renew (renew) ------------------------- */
+
+  function test_B5_renewRollsPrincipalOnlyForcesAutoRenewOff() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, true); // auto-renew ON
+    vm.warp(block.timestamp + 92 days); // matured
+    _openCohort(2); // fresh cohort to renew into
+
+    uint256 adapterBefore = usdt.balanceOf(address(adapter));
+    uint256 totalBefore = locked.totalPrincipalAmount();
+
+    vm.prank(bot);
+    locked.renewPosition(alice, 0, 2);
+
+    LockedEarnPool.Position[] memory pos = locked.getUserPositions(alice);
+    assertTrue(pos[0].closed, "old position closed");
+    assertEq(pos[1].principal, 50_000 ether, "principal rolled into the new term");
+    assertEq(pos[1].cohortId, 2);
+    assertFalse(pos[1].autoRenew, "one-term cap: new position has auto-renew forced off");
+    assertEq(locked.totalPrincipalAmount(), totalBefore, "principal moved, not created");
+    assertEq(usdt.balanceOf(address(adapter)), adapterBefore, "renewal moves no funds");
+  }
+
+  function test_B5_renewNonBotReverts() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, true);
+    vm.warp(block.timestamp + 92 days);
+    _openCohort(2);
+
+    vm.prank(alice);
+    vm.expectRevert();
+    locked.renewPosition(alice, 0, 2);
+  }
+
+  /* ------------------------- B6: toggle T-window lock ------------------------- */
+
+  function test_B6_toggleAutoRenewOutsideLockWindow() public {
+    vm.warp(T0);
+    _openCohort(1); // maturity = now + 91 days, lock window 32 days
+    _depositLocked(alice, 1, 50_000 ether, false);
+
+    vm.prank(alice);
+    locked.toggleAutoRenew(0); // now + 32d < maturity -> allowed
+    LockedEarnPool.Position[] memory pos = locked.getUserPositions(alice);
+    assertTrue(pos[0].autoRenew, "toggled on outside the lock window");
+  }
+
+  function test_B6_toggleAutoRenewLockedAtWindowBoundary() public {
+    vm.warp(T0);
+    uint256 maturity = block.timestamp + 91 days;
+    _setCohort(1, 90, block.timestamp + 1 days, maturity, true);
+    _depositLocked(alice, 1, 50_000 ether, false);
+
+    // exactly T-32: block.timestamp + 32d == maturity, guard uses '<' so it reverts
+    vm.warp(maturity - 32 days);
+    vm.prank(alice);
+    vm.expectRevert("auto renew locked (T-30)");
+    locked.toggleAutoRenew(0);
+  }
+
+  /* --------------------------- B7: one-click reinvest --------------------------- */
+
+  function test_B7_reinvestRollsFundedPayoutIntoNewCohort() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, false);
+    vm.warp(block.timestamp + 92 days); // matured
+    _openCohort(2); // reinvest target, deposit window open
+
+    vm.prank(alice);
+    locked.requestMaturityWithdraw(0);
+    _fundAdapter(50_000 ether);
+    vm.prank(bot);
+    adapter.finishLockedWithdraw(50_000 ether); // batch confirmed
+
+    uint256 adapterBefore = usdt.balanceOf(address(adapter));
+    vm.prank(alice);
+    locked.reinvest(0, 2);
+
+    LockedEarnPool.Position[] memory pos = locked.getUserPositions(alice);
+    assertEq(pos.length, 2, "new position appended");
+    assertEq(pos[1].principal, 50_000 ether, "funded payout rolled as principal");
+    assertEq(pos[1].cohortId, 2);
+    assertFalse(pos[1].autoRenew, "one-term cap on reinvest too");
+    assertEq(locked.totalPrincipalAmount(), 50_000 ether, "principal re-booked");
+    assertEq(usdt.balanceOf(address(adapter)), adapterBefore + 50_000 ether, "funds return to adapter custody");
+    assertEq(locked.totalPendingWithdraw(), 0, "confirmed request consumed");
+  }
+
+  function test_B7_reinvestBlockedByDepositPauseButClaimStaysOpen() public {
+    vm.warp(T0);
+    _openCohort(1);
+    _depositLocked(alice, 1, 50_000 ether, false);
+    vm.warp(block.timestamp + 92 days);
+    _openCohort(2);
+
+    vm.prank(alice);
+    locked.requestMaturityWithdraw(0);
+    _fundAdapter(50_000 ether);
+    vm.prank(bot);
+    adapter.finishLockedWithdraw(50_000 ether);
+
+    // wind-down blocks reinvest (entry-side), but claim stays open as the escape hatch
+    vm.prank(manager);
+    locked.setDepositPaused(true);
+
+    vm.prank(alice);
+    vm.expectRevert("deposit paused");
+    locked.reinvest(0, 2);
+
+    vm.prank(alice);
+    locked.claimWithdraw(alice, 0);
+    assertEq(usdt.balanceOf(alice), 50_000 ether, "claim remains available during wind-down");
+  }
+
+  /* --------------------------- B8: setCohort guardrails --------------------------- */
+
+  function test_B8_setCohortMaturityGuardrails() public {
+    vm.warp(T0);
+    uint256 dl = block.timestamp + 1 days;
+    uint256 nominalEnd = dl + 90 days;
+
+    _setCohort(1, 90, dl, nominalEnd, true); // maturity == nominal end: ok
+
+    vm.prank(bot);
+    vm.expectRevert("maturity before term end");
+    locked.setCohort(2, 90, dl, nominalEnd - 1, true);
+
+    vm.prank(bot);
+    vm.expectRevert("maturity too late");
+    locked.setCohort(3, 90, dl, nominalEnd + 31 days + 1, true); // beyond MAX_ALIGN_WINDOW
+
+    vm.prank(bot);
+    vm.expectRevert("term is zero");
+    locked.setCohort(4, 0, dl, nominalEnd, true);
+  }
+
+  function test_B8_setCohortMaxAlignWindowBoundaryOk() public {
+    vm.warp(T0);
+    uint256 dl = block.timestamp + 1 days;
+    uint256 nominalEnd = dl + 90 days;
+    // exactly nominalEnd + 31 days (MAX_ALIGN_WINDOW) is accepted
+    _setCohort(1, 90, dl, nominalEnd + 31 days, true);
+    (, , uint256 maturityTime, bool enabled) = locked.cohorts(1);
+    assertEq(maturityTime, nominalEnd + 31 days);
+    assertTrue(enabled);
+  }
+
+  function test_B8_setCohortIsBotOnly() public {
+    vm.warp(T0);
+    vm.prank(manager); // manager no longer holds this power (moved to BOT)
+    vm.expectRevert();
+    locked.setCohort(1, 90, block.timestamp + 1 days, block.timestamp + 91 days, true);
+  }
+
+  /* --------------------------- deposit-side guards --------------------------- */
+
+  function test_B_depositIntoDisabledCohortReverts() public {
+    vm.warp(T0);
+    _setCohort(1, 90, block.timestamp + 1 days, block.timestamp + 91 days, false); // disabled
+
+    usdt.mint(alice, 1_000 ether);
+    vm.startPrank(alice);
+    usdt.approve(address(locked), 1_000 ether);
+    vm.expectRevert("cohort not enabled");
+    locked.deposit(1, 1_000 ether, alice, false);
+    vm.stopPrank();
+  }
+
+  function test_B_depositPastDeadlineReverts() public {
+    vm.warp(T0);
+    _openCohort(1);
+    vm.warp(block.timestamp + 2 days); // past the deposit deadline
+
+    usdt.mint(alice, 1_000 ether);
+    vm.startPrank(alice);
+    usdt.approve(address(locked), 1_000 ether);
+    vm.expectRevert("deposit window closed");
+    locked.deposit(1, 1_000 ether, alice, false);
+    vm.stopPrank();
+  }
+}

--- a/test/surfin/LockedEarnPool.t.sol
+++ b/test/surfin/LockedEarnPool.t.sol
@@ -268,7 +268,7 @@ contract LockedEarnPoolTest is SurfinTestBase {
 
     uint256 adapterBefore = usdt.balanceOf(address(adapter));
     vm.prank(alice);
-    locked.reinvest(0, 2);
+    locked.reinvest(0, 2, 50_000 ether);
 
     LockedEarnPool.Position[] memory pos = locked.getUserPositions(alice);
     assertEq(pos.length, 2, "new position appended");
@@ -299,10 +299,10 @@ contract LockedEarnPoolTest is SurfinTestBase {
 
     vm.prank(alice);
     vm.expectRevert("deposit paused");
-    locked.reinvest(0, 2);
+    locked.reinvest(0, 2, 50_000 ether);
 
     vm.prank(alice);
-    locked.claimWithdraw(alice, 0);
+    locked.claimWithdraw(alice, 0, 50_000 ether);
     assertEq(usdt.balanceOf(alice), 50_000 ether, "claim remains available during wind-down");
   }
 
@@ -324,7 +324,7 @@ contract LockedEarnPoolTest is SurfinTestBase {
     locked.setCohort(3, 90, dl, nominalEnd + 31 days + 1, true); // beyond MAX_ALIGN_WINDOW
 
     vm.prank(bot);
-    vm.expectRevert("term is zero");
+    vm.expectRevert("term too short");
     locked.setCohort(4, 0, dl, nominalEnd, true);
   }
 

--- a/test/surfin/SurfinAdapterCore.t.sol
+++ b/test/surfin/SurfinAdapterCore.t.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./SurfinTestBase.sol";
+
+/**
+ * Test group 3 / module C — SurfinAdapter (fund routing).
+ *
+ * PRD-derived expectations:
+ *  - C1 deploy cap == free idle above the hard floor (§4.6, §14.4)
+ *  - C2 settleRecall splits the recall into locked cover + fee + book + buffer (§14.5)
+ *  - C3 fundInterest may pierce the hard floor but never the fee earmark (§4.2)
+ *  - C4 claimFee only ever moves the earmark to feeReceiver (§12)
+ *
+ * settleRecall's happy path and insufficiency guard are already covered by
+ * SurfinAdapterSettleRecall.t.sol; C2 here adds the fee-only / buffer angle.
+ */
+contract SurfinAdapterCoreTest is SurfinTestBase {
+  /* ------------------------------- C1: deploy ------------------------------- */
+
+  function test_C1_deployCapIsFreeIdleMinusFloor() public {
+    _depositFlex(alice, 100_000 ether); // idle 100k, hardFloor 3% = 3k
+    assertEq(adapter.maxDeployToSurfin(), 97_000 ether, "deployable == idle - floor");
+
+    vm.prank(manager);
+    adapter.deployToSurfin(97_000 ether);
+    assertEq(usdt.balanceOf(surfinWallet), 97_000 ether, "sent straight to Surfin wallet");
+    assertEq(adapter.deployedToSurfin(), 97_000 ether, "book value tracks the deploy");
+    assertEq(adapter.idleBalance(), 3_000 ether, "hard floor retained on the adapter");
+  }
+
+  function test_C1_deployOneWeiOverCapReverts() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(manager);
+    vm.expectRevert("exceeds deployable");
+    adapter.deployToSurfin(97_000 ether + 1);
+  }
+
+  function test_C1_deployExcludesFeeEarmarkFromDeployable() public {
+    _depositFlex(alice, 100_000 ether);
+    _settleRecall(10_000 ether, 0, 10_000 ether, 0); // idle 110k, fee 10k
+
+    // freeIdle = 110k - 10k fee = 100k; floor = 3% * 100k book = 3k -> deployable 97k
+    assertEq(adapter.maxDeployToSurfin(), 97_000 ether, "fee earmark excluded from deployable");
+  }
+
+  function test_C1_deployOnlyManager() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(bot);
+    vm.expectRevert();
+    adapter.deployToSurfin(1 ether);
+  }
+
+  function test_C1_deployWhenPausedReverts() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(pauser);
+    adapter.pause();
+    vm.prank(manager);
+    vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+    adapter.deployToSurfin(1 ether);
+  }
+
+  function test_C1_deployZeroReverts() public {
+    vm.prank(manager);
+    vm.expectRevert("amount is zero");
+    adapter.deployToSurfin(0);
+  }
+
+  /* ---------------------------- C2: settleRecall ---------------------------- */
+
+  function test_C2_settleRecallFeeAndBufferWithoutLockedCover() public {
+    _depositFlex(alice, 100_000 ether); // adapter 100k
+    _settleRecall(5_000 ether, 0, 2_000 ether, 500_000 ether);
+
+    assertEq(adapter.accruedFee(), 2_000 ether, "fee earmarked");
+    assertEq(adapter.deployedToSurfin(), 500_000 ether, "book absolutely reset");
+    assertEq(adapter.idleBalance(), 105_000 ether, "recall lands as buffer (prior 100k + 5k)");
+  }
+
+  function test_C2_settleRecallBookValueCanDropToZero() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(manager);
+    adapter.deployToSurfin(90_000 ether);
+    assertEq(adapter.deployedToSurfin(), 90_000 ether);
+
+    _settleRecall(90_000 ether, 0, 0, 0); // full recall, book reset to 0
+    assertEq(adapter.deployedToSurfin(), 0, "book value reset to zero on full recall");
+  }
+
+  /* ---------------------------- C3: fundInterest ---------------------------- */
+
+  function test_C3_fundInterestPiercesFloorAndFundsDistributor() public {
+    _depositFlex(alice, 100_000 ether); // idle 100k, floor 3k
+
+    vm.prank(manager);
+    adapter.fundInterest(100_000 ether); // consumes the whole balance, floor included
+
+    assertEq(usdt.balanceOf(address(distributor)), 100_000 ether, "interest routed to distributor");
+    assertEq(adapter.idleBalance(), 0, "floor may be pierced by interest");
+    assertLt(adapter.idleBalance(), adapter.hardFloor(), "confirmed below floor");
+  }
+
+  function test_C3_fundInterestNeverPiercesFeeEarmark() public {
+    _depositFlex(alice, 100_000 ether);
+    _settleRecall(100_000 ether, 0, 100_000 ether, 0); // idle 200k, fee 100k
+
+    // freeIdle above the fee earmark is 100k; one wei more must revert
+    vm.prank(manager);
+    vm.expectRevert("insufficient idle");
+    adapter.fundInterest(100_000 ether + 1);
+  }
+
+  function test_C3_fundInterestOnlyManager() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(bot);
+    vm.expectRevert();
+    adapter.fundInterest(1 ether);
+  }
+
+  function test_C3_fundInterestZeroReverts() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(manager);
+    vm.expectRevert("amount is zero");
+    adapter.fundInterest(0);
+  }
+
+  /* ------------------------------ C4: claimFee ------------------------------ */
+
+  function test_C4_claimFeeMovesEarmarkToFeeReceiver() public {
+    _depositFlex(alice, 100_000 ether);
+    _settleRecall(10_000 ether, 0, 10_000 ether, 0); // accruedFee 10k
+
+    vm.prank(bot);
+    adapter.claimFee(4_000 ether);
+    assertEq(usdt.balanceOf(feeReceiver), 4_000 ether, "fee paid to feeReceiver only");
+    assertEq(adapter.accruedFee(), 6_000 ether, "earmark decremented");
+  }
+
+  function test_C4_claimFeeExceedingAccruedReverts() public {
+    _depositFlex(alice, 100_000 ether);
+    _settleRecall(10_000 ether, 0, 10_000 ether, 0);
+    vm.prank(bot);
+    vm.expectRevert("invalid amount");
+    adapter.claimFee(10_000 ether + 1);
+  }
+
+  function test_C4_claimFeeOnlyBot() public {
+    _depositFlex(alice, 100_000 ether);
+    _settleRecall(10_000 ether, 0, 10_000 ether, 0);
+    vm.prank(alice);
+    vm.expectRevert();
+    adapter.claimFee(1 ether);
+  }
+}

--- a/test/surfin/SurfinAdapterGuard.t.sol
+++ b/test/surfin/SurfinAdapterGuard.t.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../src/surfin/SurfinAdapter.sol";
+import "../../src/surfin/FlexEarnPool.sol";
+import "../../src/surfin/LockedEarnPool.sol";
+import "../../src/mock/MockERC20.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/**
+ * Regression suite for the single-pot floor+earmark withdrawal guard
+ * (flex-drain-solution-plan.md §2). Proves the two confirmed holes are closed:
+ *
+ *  - finishFlexWithdraw / finishLockedWithdraw must not push cash below the
+ *    protected reserve (accruedFee + 3% hardFloor over both pools' live book).
+ *  - CreditFundBase.finishWithdraw must not let withdrawQuota accumulate beyond
+ *    the pool's real pending obligation.
+ *  - finishLockedWithdraw is MANAGER-gated (weekly settlement), not BOT.
+ */
+contract SurfinAdapterGuard is Test {
+  MockERC20 usdt;
+  SurfinAdapter adapter;
+  FlexEarnPool flex;
+  LockedEarnPool locked;
+
+  address admin = makeAddr("admin");
+  address manager = makeAddr("manager");
+  address pauser = makeAddr("pauser");
+  address bot = makeAddr("bot");
+  address surfinWallet = makeAddr("surfinWallet");
+  address userA = makeAddr("userA");
+  address userB = makeAddr("userB");
+
+  uint256 constant FLOOR_RATE = 3e16; // 3%
+
+  function setUp() public {
+    usdt = new MockERC20("USDT", "USDT");
+
+    FlexEarnPool flexImpl = new FlexEarnPool();
+    LockedEarnPool lockedImpl = new LockedEarnPool();
+    SurfinAdapter adapterImpl = new SurfinAdapter(address(usdt));
+
+    flex = FlexEarnPool(
+      address(
+        new ERC1967Proxy(
+          address(flexImpl),
+          abi.encodeWithSelector(
+            flexImpl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            bot,
+            address(usdt),
+            address(this),
+            "Flex",
+            "FLEX"
+          )
+        )
+      )
+    );
+    locked = LockedEarnPool(
+      address(
+        new ERC1967Proxy(
+          address(lockedImpl),
+          abi.encodeWithSelector(
+            lockedImpl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            bot,
+            address(usdt),
+            address(this),
+            "Locked",
+            "LOCK"
+          )
+        )
+      )
+    );
+    adapter = SurfinAdapter(
+      address(
+        new ERC1967Proxy(
+          address(adapterImpl),
+          abi.encodeWithSelector(
+            adapterImpl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            bot,
+            address(flex),
+            address(locked),
+            surfinWallet
+          )
+        )
+      )
+    );
+
+    vm.startPrank(admin);
+    flex.setAdapter(address(adapter));
+    locked.setAdapter(address(adapter));
+    vm.stopPrank();
+  }
+
+  function _depositFlex(address who, uint256 amount) internal {
+    usdt.mint(who, amount);
+    vm.startPrank(who);
+    usdt.approve(address(flex), amount);
+    flex.deposit(amount, who);
+    vm.stopPrank();
+  }
+
+  // ---- flex withdraw guard: cannot break the 3% hard floor ----
+
+  function test_finishFlexWithdraw_reverts_when_breaks_floor() public {
+    _depositFlex(userA, 100_000 ether); // adapter 100k, totalPrincipal 100k
+    // hardFloor = 3% * 100k = 3k -> available = 97k; pushing 97_001 must revert
+    vm.prank(bot);
+    vm.expectRevert();
+    adapter.finishFlexWithdraw(97_001 ether);
+  }
+
+  function test_finishFlexWithdraw_ok_down_to_floor() public {
+    _depositFlex(userA, 100_000 ether);
+    vm.prank(userA);
+    flex.requestWithdraw(97_000 ether); // one batch == available
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(97_000 ether); // exactly to the floor -> ok
+    assertEq(usdt.balanceOf(address(adapter)), 3_000 ether, "3% floor preserved");
+  }
+
+  // ---- withdrawQuota cap: pushed cash cannot exceed real pending ----
+
+  function test_finishFlexWithdraw_reverts_when_overpush_beyond_pending() public {
+    _depositFlex(userA, 100_000 ether);
+    vm.prank(userA);
+    flex.requestWithdraw(40_000 ether); // pending 40k
+    // 90k <= available(97k) passes the reserve guard, but leaves 50k surplus
+    // quota > 40k pending -> CreditFundBase cap must revert
+    vm.prank(bot);
+    vm.expectRevert();
+    adapter.finishFlexWithdraw(90_000 ether);
+  }
+
+  function test_finishFlexWithdraw_ok_exact_batch() public {
+    _depositFlex(userA, 100_000 ether);
+    vm.prank(userA);
+    flex.requestWithdraw(40_000 ether);
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(40_000 ether); // exact batch, no surplus
+    assertEq(flex.confirmedBatchId(), 1, "batch confirmed");
+    assertEq(flex.withdrawQuota(), 0, "no surplus quota");
+  }
+
+  // partial funding followed by a cancellation must NOT wedge batch confirmation:
+  // the surplus-quota check runs only on funding pushes (amount > 0), so a 0-amount
+  // tick still confirms the shrunk batch and the remaining user can claim.
+  function test_finishFlexWithdraw_cancel_after_partial_fund_does_not_wedge() public {
+    _depositFlex(userA, 100_000 ether);
+    vm.startPrank(userA);
+    flex.requestWithdraw(40_000 ether); // req idx0, batch1
+    flex.requestWithdraw(60_000 ether); // req idx1, batch1 (total 100k)
+    vm.stopPrank();
+
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(70_000 ether); // partial fund: quota 70k < batch 100k
+    assertEq(flex.confirmedBatchId(), 0, "not yet confirmed");
+
+    vm.prank(userA);
+    flex.cancelWithdraw(1); // cancel the 60k request -> batch1 now 40k, quota still 70k
+
+    // a 0-amount tick confirms the 40k batch despite the 30k surplus quota (no revert)
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(0);
+    assertEq(flex.confirmedBatchId(), 1, "batch confirmed by tick, no DoS");
+  }
+
+  // ---- finishLockedWithdraw is BOT-gated (recall-late buffer cover) ----
+
+  function test_finishLockedWithdraw_bot_ok() public {
+    _depositFlex(userA, 100_000 ether); // adapter 100k, flex principal 100k
+    _lockedMaturedRequest(userB, 10_000 ether); // matured locked batch of 10k
+    // recall has not landed: BOT covers the matured locked batch out of the buffer
+    vm.prank(bot);
+    adapter.finishLockedWithdraw(10_000 ether);
+    assertEq(locked.confirmedBatchId(), 1, "locked batch covered by bot from buffer");
+  }
+
+  function test_finishLockedWithdraw_nonbot_reverts() public {
+    _depositFlex(userA, 100_000 ether);
+    vm.prank(manager); // manager holds MANAGER, not BOT
+    vm.expectRevert();
+    adapter.finishLockedWithdraw(1 ether);
+  }
+
+  function test_finishLockedWithdraw_reverts_when_breaks_floor() public {
+    _depositFlex(userA, 100_000 ether);
+    _lockedMaturedRequest(userB, 10_000 ether); // adapter now holds 110k
+    // floor = 3% * (100k flex + 10k locked pending) = 3.3k -> available = 106.7k
+    vm.prank(bot);
+    vm.expectRevert();
+    adapter.finishLockedWithdraw(106_701 ether);
+  }
+
+  // ---- fundInterest may consume the hard floor, but never the fee earmark ----
+
+  function test_fundInterest_consumes_floor_not_fee() public {
+    _depositFlex(userA, 100_000 ether); // adapter 100k, floor = 3k
+
+    // set a 10k fee earmark by settling a recall that only carries fee
+    MockDistributor dist = new MockDistributor(address(usdt));
+    vm.prank(manager);
+    adapter.setInterestDistributor(address(dist));
+    usdt.mint(manager, 10_000 ether);
+    vm.startPrank(manager);
+    usdt.approve(address(adapter), 10_000 ether);
+    adapter.settleRecall(10_000 ether, 0, 10_000 ether, 0); // adapter 110k, accruedFee 10k
+    vm.stopPrank();
+
+    // funding 100k == bal(110k) - fee(10k): allowed, and it eats through the floor
+    vm.prank(manager);
+    adapter.fundInterest(100_000 ether);
+    assertEq(usdt.balanceOf(address(adapter)), 10_000 ether, "only the fee earmark is left");
+    assertEq(adapter.accruedFee(), 10_000 ether, "fee still fully backed");
+    assertEq(adapter.instantWithdrawable(), 0, "floor was consumed, nothing withdrawable");
+
+    // one wei more would dip into the fee earmark -> revert
+    vm.prank(manager);
+    vm.expectRevert("insufficient idle");
+    adapter.fundInterest(1);
+  }
+
+  // deposit into a cohort, warp past maturity, request maturity withdraw
+  function _lockedMaturedRequest(address who, uint256 amount) internal {
+    vm.warp(1_000_000);
+    vm.prank(bot);
+    locked.setCohort(
+      1, // cohortId
+      90, // termDays
+      block.timestamp + 1 days, // depositDeadline
+      block.timestamp + 1 days + 90 days, // maturityTime
+      true
+    );
+    usdt.mint(who, amount);
+    vm.startPrank(who);
+    usdt.approve(address(locked), amount);
+    locked.deposit(1, amount, who, false);
+    vm.stopPrank();
+    vm.warp(block.timestamp + 1 days + 91 days); // past maturity
+    vm.prank(who);
+    locked.requestMaturityWithdraw(0);
+  }
+}
+
+/// minimal IInterestDistributor: pulls the funded amount from the adapter
+contract MockDistributor {
+  address public asset;
+
+  constructor(address _asset) {
+    asset = _asset;
+  }
+
+  function notifyReward(uint256 amount) external {
+    IERC20(asset).transferFrom(msg.sender, address(this), amount);
+  }
+}

--- a/test/surfin/SurfinAdapterGuard.t.sol
+++ b/test/surfin/SurfinAdapterGuard.t.sol
@@ -151,9 +151,9 @@ contract SurfinAdapterGuard is Test {
     assertEq(flex.withdrawQuota(), 0, "no surplus quota");
   }
 
-  // partial funding followed by a cancellation must NOT wedge batch confirmation:
-  // the surplus-quota check runs only on funding pushes (amount > 0), so a 0-amount
-  // tick still confirms the shrunk batch and the remaining user can claim.
+  // partial funding followed by a cancellation must NOT wedge batch confirmation: the
+  // cancellation hands the now-unbacked surplus straight back to the adapter, and the
+  // shrunk batch confirms on the next tick.
   function test_finishFlexWithdraw_cancel_after_partial_fund_does_not_wedge() public {
     _depositFlex(userA, 100_000 ether);
     vm.startPrank(userA);
@@ -166,12 +166,66 @@ contract SurfinAdapterGuard is Test {
     assertEq(flex.confirmedBatchId(), 0, "not yet confirmed");
 
     vm.prank(userA);
-    flex.cancelWithdraw(1, 60_000 ether); // cancel the 60k request -> batch1 now 40k, quota still 70k
+    flex.cancelWithdraw(1, 60_000 ether); // cancel the 60k -> batch1 now 40k
+    assertEq(flex.withdrawQuota(), 40_000 ether, "surplus 30k returned to adapter");
 
-    // a 0-amount tick confirms the 40k batch despite the 30k surplus quota (no revert)
+    // a 0-amount tick confirms the 40k batch (no revert)
     vm.prank(bot);
     adapter.finishFlexWithdraw(0);
     assertEq(flex.confirmedBatchId(), 1, "batch confirmed by tick, no DoS");
+  }
+
+  // M02, the orphan the first predicate could not see.
+  //
+  // Comparing withdrawQuota against totalPendingWithdraw also counts confirmed-but-
+  // unclaimed payouts whose cash is already in the pool. A confirmed batch sitting in the
+  // queue therefore MASKS a surplus: the predicate stays false, the orphan survives the
+  // cancellation, and it only surfaces once the final claim drops pending to 0 — by which
+  // point funding pushes revert with "quota exceeds pending" and no 0-amount tick can
+  // drain it (the cancelled batch total is 0, so the confirmation loop subtracts nothing).
+  //
+  // Measured against the UNCONFIRMED obligation instead, the surplus is returned at the
+  // cancellation — the moment it actually stops backing anything.
+  function test_cancel_orphanQuota_returned_even_when_masked_by_confirmed_batch() public {
+    _depositFlex(userA, 100_000 ether);
+
+    vm.prank(userA);
+    flex.requestWithdraw(600 ether); // batch1
+    vm.warp(block.timestamp + 1 days); // roll to a new day so the next request opens batch2
+    vm.prank(userA);
+    flex.requestWithdraw(300 ether); // batch2
+
+    // partial fund: covers batch1 (600) exactly, leaving 299 that batch2 (300) cannot use
+    uint256 adapterBefore = usdt.balanceOf(address(adapter));
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(899 ether);
+    assertEq(flex.confirmedBatchId(), 1, "batch1 confirmed");
+    assertEq(flex.withdrawQuota(), 299 ether, "299 parked for batch2");
+    assertEq(flex.totalConfirmedUnclaimed(), 600 ether, "batch1 payout awaiting claim");
+
+    // cancel batch2 -> nothing unconfirmed is left, so the 299 backs nothing. The wider
+    // predicate (299 > totalPendingWithdraw 600) was false here and stranded it.
+    vm.prank(userA);
+    flex.cancelWithdraw(1, 300 ether);
+    assertEq(flex.withdrawQuota(), 0, "orphan quota returned at cancellation");
+    assertEq(usdt.balanceOf(address(adapter)), adapterBefore - 600 ether, "only batch1's cash left the adapter");
+
+    // the claim then unwinds both counters to zero...
+    vm.prank(userA);
+    flex.claimWithdraw(userA, 0, 600 ether);
+    assertEq(flex.totalPendingWithdraw(), 0, "queue drained");
+    assertEq(flex.totalConfirmedUnclaimed(), 0, "confirmed-unclaimed drained");
+    assertEq(flex.withdrawQuota(), 0, "no residue");
+
+    // ...and the funding channel is still open. With the orphan stranded the pool held 299
+    // against pending 0, so every finishFlexWithdraw(amount > 0) reverted from here on. The
+    // new request reuses the emptied batch2 (same day, still unconfirmed).
+    vm.prank(userA);
+    flex.requestWithdraw(500 ether);
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(500 ether);
+    assertEq(flex.confirmedBatchId(), 2, "funding still works after the sequence");
+    assertEq(flex.withdrawQuota(), 0, "fully consumed by the new batch");
   }
 
   // ---- finishLockedWithdraw is BOT-gated (recall-late buffer cover) ----

--- a/test/surfin/SurfinAdapterGuard.t.sol
+++ b/test/surfin/SurfinAdapterGuard.t.sol
@@ -166,7 +166,7 @@ contract SurfinAdapterGuard is Test {
     assertEq(flex.confirmedBatchId(), 0, "not yet confirmed");
 
     vm.prank(userA);
-    flex.cancelWithdraw(1); // cancel the 60k request -> batch1 now 40k, quota still 70k
+    flex.cancelWithdraw(1, 60_000 ether); // cancel the 60k request -> batch1 now 40k, quota still 70k
 
     // a 0-amount tick confirms the 40k batch despite the 30k surplus quota (no revert)
     vm.prank(bot);

--- a/test/surfin/SurfinAdapterSettleRecall.t.sol
+++ b/test/surfin/SurfinAdapterSettleRecall.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../src/surfin/SurfinAdapter.sol";
+import "../../src/surfin/FlexEarnPool.sol";
+import "../../src/surfin/LockedEarnPool.sol";
+import "../../src/mock/MockERC20.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/**
+ * Regression suite for settleRecall (flex-drain-solution-plan.md §2.5): the weekly
+ * multisig recall settlement that replaces repayFromSurfin + bookFee. The manager
+ * transfers recalled USDT in and, in one call, resets the Surfin book value, sets
+ * the fee earmark, covers the locked queue, and leaves the remainder as buffer.
+ */
+contract SurfinAdapterSettleRecall is Test {
+  MockERC20 usdt;
+  SurfinAdapter adapter;
+  FlexEarnPool flex;
+  LockedEarnPool locked;
+
+  address admin = makeAddr("admin");
+  address manager = makeAddr("manager");
+  address pauser = makeAddr("pauser");
+  address bot = makeAddr("bot");
+  address surfinWallet = makeAddr("surfinWallet");
+  address userA = makeAddr("userA");
+
+  function setUp() public {
+    usdt = new MockERC20("USDT", "USDT");
+
+    FlexEarnPool flexImpl = new FlexEarnPool();
+    LockedEarnPool lockedImpl = new LockedEarnPool();
+    SurfinAdapter adapterImpl = new SurfinAdapter(address(usdt));
+
+    flex = FlexEarnPool(
+      address(
+        new ERC1967Proxy(
+          address(flexImpl),
+          abi.encodeWithSelector(
+            flexImpl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            bot,
+            address(usdt),
+            address(this),
+            "Flex",
+            "FLEX"
+          )
+        )
+      )
+    );
+    locked = LockedEarnPool(
+      address(
+        new ERC1967Proxy(
+          address(lockedImpl),
+          abi.encodeWithSelector(
+            lockedImpl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            bot,
+            address(usdt),
+            address(this),
+            "Locked",
+            "LOCK"
+          )
+        )
+      )
+    );
+    adapter = SurfinAdapter(
+      address(
+        new ERC1967Proxy(
+          address(adapterImpl),
+          abi.encodeWithSelector(
+            adapterImpl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            bot,
+            address(flex),
+            address(locked),
+            surfinWallet
+          )
+        )
+      )
+    );
+
+    vm.startPrank(admin);
+    flex.setAdapter(address(adapter));
+    locked.setAdapter(address(adapter));
+    vm.stopPrank();
+  }
+
+  // set up a matured locked position of `amount`; leaves a 1-batch locked queue.
+  // The deposit forwards `amount` to the adapter.
+  function _lockedMatured(address who, uint256 amount) internal {
+    vm.warp(1_000_000);
+    vm.prank(bot);
+    locked.setCohort(1, 90, block.timestamp + 1 days, block.timestamp + 91 days, true);
+    usdt.mint(who, amount);
+    vm.startPrank(who);
+    usdt.approve(address(locked), amount);
+    locked.deposit(1, amount, who, false);
+    vm.stopPrank();
+    vm.warp(block.timestamp + 92 days);
+    vm.prank(who);
+    locked.requestMaturityWithdraw(0);
+  }
+
+  function _managerSettle(
+    uint256 recalledAmount,
+    uint256 lockedCoverAmount,
+    uint256 feeAmount,
+    uint256 bookValue
+  ) internal {
+    usdt.mint(manager, recalledAmount);
+    vm.startPrank(manager);
+    usdt.approve(address(adapter), recalledAmount);
+    adapter.settleRecall(recalledAmount, lockedCoverAmount, feeAmount, bookValue);
+    vm.stopPrank();
+  }
+
+  function test_settleRecall_reverts_when_recall_insufficient() public {
+    // 4k cover + 2k fee = 6k > 5k recalled
+    vm.prank(manager);
+    vm.expectRevert("recall insufficient");
+    adapter.settleRecall(5_000 ether, 4_000 ether, 2_000 ether, 0);
+  }
+
+  function test_settleRecall_onlyManager() public {
+    vm.prank(bot);
+    vm.expectRevert();
+    adapter.settleRecall(1 ether, 0, 0, 0);
+  }
+
+  function test_settleRecall_happy_covers_locked_sets_fee_book_and_buffer() public {
+    _lockedMatured(userA, 10_000 ether); // adapter holds 10k; locked pending 10k, batch1
+    uint256 adapterBefore = usdt.balanceOf(address(adapter));
+    assertEq(adapterBefore, 10_000 ether, "adapter holds the locked deposit");
+
+    // recall 12k: cover 10k locked, 1k fee, 1k remainder -> buffer; book reset to 500k
+    _managerSettle(12_000 ether, 10_000 ether, 1_000 ether, 500_000 ether);
+
+    assertEq(locked.confirmedBatchId(), 1, "locked matured batch confirmed");
+    assertEq(adapter.accruedFee(), 1_000 ether, "fee earmarked");
+    assertEq(adapter.deployedToSurfin(), 500_000 ether, "deployed book absolutely reset");
+    // adapter had 10k, +12k in, -10k pushed to locked pool = 12k remaining
+    assertEq(usdt.balanceOf(address(adapter)), 12_000 ether, "cover leaves remainder + prior cash as buffer");
+  }
+
+  function test_settleRecall_book_value_can_increase() public {
+    // 80% of Surfin interest rolls into principal -> book value goes UP
+    _managerSettle(0, 0, 0, 1_000_000 ether);
+    assertEq(adapter.deployedToSurfin(), 1_000_000 ether, "book value raised via absolute reset");
+  }
+}

--- a/test/surfin/SurfinConflict.t.sol
+++ b/test/surfin/SurfinConflict.t.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./SurfinTestBase.sol";
+
+/**
+ * Test group 2 — PRD vs contract conflict points (highest-value review targets).
+ *
+ * These tests assert the CURRENT on-chain behavior on purpose, so the suite stays
+ * green, while documenting where it diverges from the PRD. Each one is a concrete
+ * "PRD expects X, contract does Y" artifact to take to product/contract owners. If a
+ * divergence is confirmed a real gap, flip the assertion after the fix lands.
+ */
+contract SurfinConflict is SurfinTestBase {
+  /* ============================================================================
+   * CONFLICT-1 — claim-type operations are pause-gated.
+   *
+   * PRD §4.9: claim-type actions are NOT subject to pause; already-funded money must
+   *           stay claimable even in the Frozen state ("users always have an exit").
+   * CONTRACT: CreditFundBase.claimWithdraw and InterestDistributor.claim both carry
+   *           whenNotPaused, so pausing blocks users from claiming funds that were
+   *           already pushed to them.
+   * ==========================================================================*/
+
+  /// @dev A confirmed, fully-funded flex withdrawal becomes unclaimable once paused.
+  ///      PRD §4.9 expects this claim to succeed.
+  function test_conflict1_flexClaimBlockedByPause_divergesFromPRD() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(alice);
+    flex.requestWithdraw(50_000 ether);
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(50_000 ether); // batch confirmed, 50k cash sits in the pool
+
+    vm.prank(pauser);
+    flex.pause();
+
+    // PRD §4.9 expectation: alice can still claim her already-funded 50k.
+    // CURRENT behavior: whenNotPaused reverts the claim.
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+    flex.claimWithdraw(alice, 0);
+  }
+
+  /// @dev The same divergence for interest: a valid, funded Merkle claim is blocked
+  ///      while the distributor is paused. PRD §4.9 expects interest claims to remain open.
+  function test_conflict1_interestClaimBlockedByPause_divergesFromPRD() public {
+    _depositFlex(alice, 100_000 ether); // gives the adapter idle cash to fund interest
+
+    vm.prank(manager);
+    adapter.fundInterest(1_000 ether); // move 1k into the distributor
+
+    bytes32 root = _leaf(alice, 1_000 ether);
+    _publishRoot(root);
+
+    vm.prank(pauser);
+    distributor.pause();
+
+    bytes32[] memory proof = new bytes32[](0);
+    // PRD §4.9 expectation: alice claims her 1k interest. CURRENT: whenNotPaused reverts.
+    vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+    distributor.claim(alice, 1_000 ether, proof);
+  }
+
+  /// @dev Counter-check: depositPaused (wind-down) intentionally does NOT block claims
+  ///      (only entry-side ops), which matches PRD §4.9's "always an exit". This is the
+  ///      behavior the pause() gate above should arguably mirror.
+  function test_conflict1_depositPausedKeepsClaimOpen_matchesPRD() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(alice);
+    flex.requestWithdraw(50_000 ether);
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(50_000 ether);
+
+    vm.prank(manager);
+    flex.setDepositPaused(true); // wind-down: blocks deposits, not claims
+
+    vm.prank(alice);
+    flex.claimWithdraw(alice, 0); // succeeds
+    assertEq(usdt.balanceOf(alice), 50_000 ether, "claim stays open during wind-down");
+  }
+
+  /* ============================================================================
+   * CONFLICT-2 — early-redeem penalty is locked in and never reversed at maturity.
+   *
+   * PRD §4.4: if an early-redeem request is left unfunded until the position's own
+   *           maturity (T-30 checkpoint), the penalty is VOIDED — the request converts
+   *           to a normal maturity withdrawal (full principal) and base interest is
+   *           back-filled for the whole term.
+   * CONTRACT: requestEarlyRedeem computes the penalized payout once, at request time,
+   *           and enqueues it. There is no maturity-reversal path, so the penalty
+   *           stands no matter how long funding takes.
+   * ==========================================================================*/
+
+  function test_conflict2_earlyRedeemPenaltyStandsPastMaturity_divergesFromPRD() public {
+    vm.warp(1_000_000);
+    // cohort 1: 90-day term, deposits close at +1 day, maturity at +91 days
+    _setCohort(1, 90, block.timestamp + 1 days, block.timestamp + 91 days, true);
+    _depositLocked(alice, 1, 50_000 ether, false);
+
+    // early redeem the full position within the 30-day penalty window (0.8% default)
+    uint256 payout = locked.previewEarlyRedeem(alice, 0, 50_000 ether);
+    assertEq(payout, 49_600 ether, "0.8% penalty applied inside the window");
+    vm.prank(alice);
+    locked.requestEarlyRedeem(0, 50_000 ether); // enqueues 49,600; position closed
+
+    // the request sits unfunded until well past the position's maturity
+    vm.warp(block.timestamp + 100 days);
+
+    // fund and confirm the queued redemption
+    _fundAdapter(50_000 ether);
+    vm.prank(bot);
+    adapter.finishLockedWithdraw(49_600 ether);
+    vm.prank(alice);
+    locked.claimWithdraw(alice, 0);
+
+    // CURRENT: alice receives the penalized 49,600 even though the wait ran past
+    // maturity. PRD §4.4 expects 50,000 (penalty voided) + full-term base interest.
+    assertEq(usdt.balanceOf(alice), 49_600 ether, "penalty stands past maturity (diverges from PRD 4.4)");
+    assertLt(usdt.balanceOf(alice), 50_000 ether, "principal was reduced by a penalty that PRD would have voided");
+  }
+}

--- a/test/surfin/SurfinConflict.t.sol
+++ b/test/surfin/SurfinConflict.t.sol
@@ -38,7 +38,7 @@ contract SurfinConflict is SurfinTestBase {
     // CURRENT behavior: whenNotPaused reverts the claim.
     vm.prank(alice);
     vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
-    flex.claimWithdraw(alice, 0);
+    flex.claimWithdraw(alice, 0, 50_000 ether);
   }
 
   /// @dev The same divergence for interest: a valid, funded Merkle claim is blocked
@@ -75,7 +75,7 @@ contract SurfinConflict is SurfinTestBase {
     flex.setDepositPaused(true); // wind-down: blocks deposits, not claims
 
     vm.prank(alice);
-    flex.claimWithdraw(alice, 0); // succeeds
+    flex.claimWithdraw(alice, 0, 50_000 ether); // succeeds
     assertEq(usdt.balanceOf(alice), 50_000 ether, "claim stays open during wind-down");
   }
 
@@ -111,7 +111,7 @@ contract SurfinConflict is SurfinTestBase {
     vm.prank(bot);
     adapter.finishLockedWithdraw(49_600 ether);
     vm.prank(alice);
-    locked.claimWithdraw(alice, 0);
+    locked.claimWithdraw(alice, 0, 49_600 ether);
 
     // CURRENT: alice receives the penalized 49,600 even though the wait ran past
     // maturity. PRD §4.4 expects 50,000 (penalty voided) + full-term base interest.

--- a/test/surfin/SurfinInvariant.t.sol
+++ b/test/surfin/SurfinInvariant.t.sol
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./SurfinTestBase.sol";
+import "../../src/surfin/CreditFundBase.sol";
+
+/**
+ * Stateful handler driving random flex-pool + adapter lifecycles for the
+ * invariant runner. Every action is guarded so it never reverts spuriously
+ * (bounded amounts, skip when nothing to do), which keeps the fuzzed sequences
+ * long and the invariants meaningful rather than vacuous.
+ */
+contract FlexInvariantHandler is Test {
+  MockERC20 usdt;
+  SurfinAdapter adapter;
+  FlexEarnPool flex;
+  address bot;
+  address manager;
+  address[] internal actors;
+
+  constructor(MockERC20 _usdt, SurfinAdapter _adapter, FlexEarnPool _flex, address _bot, address _manager) {
+    usdt = _usdt;
+    adapter = _adapter;
+    flex = _flex;
+    bot = _bot;
+    manager = _manager;
+    actors.push(makeAddr("inv_actor_1"));
+    actors.push(makeAddr("inv_actor_2"));
+    actors.push(makeAddr("inv_actor_3"));
+  }
+
+  function depositFlex(uint256 actorSeed, uint256 amount) public {
+    address a = actors[actorSeed % actors.length];
+    amount = bound(amount, 1e18, 1_000_000e18);
+    usdt.mint(a, amount);
+    vm.startPrank(a);
+    usdt.approve(address(flex), amount);
+    flex.deposit(amount, a);
+    vm.stopPrank();
+  }
+
+  function requestWithdraw(uint256 actorSeed, uint256 amount) public {
+    address a = actors[actorSeed % actors.length];
+    uint256 bal = flex.balanceOf(a);
+    if (bal == 0) return;
+    amount = bound(amount, 1, bal);
+    vm.prank(a);
+    flex.requestWithdraw(amount);
+  }
+
+  function finishFlex(uint256 amount) public {
+    uint256 avail = adapter.instantWithdrawable();
+    uint256 pend = flex.totalPendingWithdraw();
+    uint256 quota = flex.withdrawQuota();
+    uint256 room = pend > quota ? pend - quota : 0;
+    uint256 max = avail < room ? avail : room;
+    amount = max == 0 ? 0 : bound(amount, 0, max);
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(amount);
+  }
+
+  function claimFlex(uint256 actorSeed) public {
+    address a = actors[actorSeed % actors.length];
+    CreditFundBase.WithdrawalRequest[] memory reqs = flex.getUserWithdrawalRequests(a);
+    for (uint256 i = 0; i < reqs.length; i++) {
+      if (reqs[i].batchId <= flex.confirmedBatchId()) {
+        vm.prank(a);
+        flex.claimWithdraw(a, i);
+        return;
+      }
+    }
+  }
+
+  function cancelFlex(uint256 actorSeed) public {
+    address a = actors[actorSeed % actors.length];
+    CreditFundBase.WithdrawalRequest[] memory reqs = flex.getUserWithdrawalRequests(a);
+    for (uint256 i = 0; i < reqs.length; i++) {
+      if (reqs[i].batchId > flex.confirmedBatchId()) {
+        vm.prank(a);
+        flex.cancelWithdraw(i);
+        return;
+      }
+    }
+  }
+
+  function deploy(uint256 amount) public {
+    uint256 max = adapter.maxDeployToSurfin();
+    if (max == 0) return;
+    amount = bound(amount, 1, max);
+    vm.prank(manager);
+    adapter.deployToSurfin(amount);
+  }
+
+  /// @dev emulate Surfin returning cash to the adapter (raw inflow), so the queue
+  ///      can keep being funded without going through the full recall settlement.
+  function recallCash(uint256 amount) public {
+    amount = bound(amount, 0, 1_000_000e18);
+    if (amount > 0) usdt.mint(address(adapter), amount);
+  }
+
+  /// @dev principal of confirmed-but-unclaimed requests across all actors.
+  function confirmedUnclaimed() external view returns (uint256 sum) {
+    uint256 confirmed = flex.confirmedBatchId();
+    for (uint256 j = 0; j < actors.length; j++) {
+      CreditFundBase.WithdrawalRequest[] memory reqs = flex.getUserWithdrawalRequests(actors[j]);
+      for (uint256 i = 0; i < reqs.length; i++) {
+        if (reqs[i].batchId <= confirmed) sum += reqs[i].amount;
+      }
+    }
+  }
+}
+
+/**
+ * Test group 1 — core invariants (highest priority). These are the "must always
+ * hold" safety properties the PRD implies (§4.5–§4.7, §14.4). The stateful runner
+ * fuzzes random flex lifecycles; the deterministic tests pin the exact PRD-derived
+ * properties for INV-2/3/4.
+ */
+contract SurfinInvariant is SurfinTestBase {
+  FlexInvariantHandler handler;
+
+  function setUp() public override {
+    super.setUp();
+    handler = new FlexInvariantHandler(usdt, adapter, flex, bot, manager);
+    targetContract(address(handler));
+  }
+
+  /* ---- INV-1: pool solvency (a confirmed batch is always fully backed by cash) ---- */
+  /// @dev provable identity: poolBalance == withdrawQuota + confirmedUnclaimed, hence
+  ///      the pool can always pay every user whose batch is already confirmed.
+  function invariant_flexPoolSolvent() public view {
+    assertGe(usdt.balanceOf(address(flex)), handler.confirmedUnclaimed(), "flex pool cannot cover confirmed claims");
+  }
+
+  /* ---- INV-3: the adapter never over-pushes past the pool's real obligation ---- */
+  /// @dev NOTE: `withdrawQuota <= totalPendingWithdraw` is deliberately NOT a global
+  ///      invariant. It is enforced only on funding pushes (finishWithdraw with
+  ///      amount > 0). A partially-funded batch that is then cancelled can strand
+  ///      surplus quota (quota > pending) until a later batch or a 0-amount tick
+  ///      consumes it — see finishWithdraw's comment and the existing
+  ///      SurfinAdapterGuard cancel-after-partial-fund regression. The always-true
+  ///      safety property is pool solvency (invariant_flexPoolSolvent above); the
+  ///      per-push guard is pinned by test_inv3_finishRevertsWhenQuotaExceedsPending.
+
+  /* ---- INV-2: the on-chain hard floor is never paid out by withdrawal flows ---- */
+  function invariant_floorNeverBreached() public view {
+    assertGe(adapter.idleBalance(), adapter.hardFloor(), "hard floor breached");
+  }
+
+  /* =========================== deterministic INV pins =========================== */
+
+  /**
+   * INV-1 (fund conservation, PRD §14 asset/liability reconciliation): across a full
+   * lifecycle no USDT is created or lost. With fee = 0 and the deployed book matching
+   * the physical Surfin holding, the perimeter identity holds at every step:
+   *   adapterIdle + flexBalance + surfinWalletBalance == principal + pending
+   */
+  function test_inv1_fundConservationAcrossLifecycle() public {
+    _depositFlex(alice, 100_000 ether); // idle 100k, principal 100k
+    _assertConservation();
+
+    vm.prank(alice);
+    flex.requestWithdraw(50_000 ether); // principal 50k, pending 50k
+    _assertConservation();
+
+    // available = idle(100k) - hardFloor(3% * 100k = 3k) = 97k >= 50k: batch fully funded
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(50_000 ether); // idle 50k, flex 50k, batch confirmed
+    _assertConservation();
+
+    vm.prank(alice);
+    flex.claimWithdraw(alice, 0); // alice +50k, flex 0, pending 0
+    _assertConservation();
+
+    // remaining idle can be deployed down to the (now smaller) floor
+    uint256 max = adapter.maxDeployToSurfin(); // freeIdle(50k) - 3% * 50k = 48.5k
+    vm.prank(manager);
+    adapter.deployToSurfin(max); // idle 1.5k, surfin 48.5k
+    _assertConservation();
+  }
+
+  /**
+   * INV-2 (hard floor protection, PRD §4.5/§4.7/§14.4) plus its single exception:
+   * withdrawal flows can never pierce the floor, but interest funding (§4.2, floor
+   * doubles as the interest reserve) is allowed to.
+   */
+  function test_inv2_floorProtectedFromWithdraw_butInterestMayPierce() public {
+    _depositFlex(alice, 100_000 ether); // idle 100k, hardFloor 3k, available 97k
+
+    // withdrawal flow cannot cross the floor
+    vm.prank(bot);
+    vm.expectRevert("exceeds available");
+    adapter.finishFlexWithdraw(97_001 ether);
+
+    // interest funding is the one path allowed to consume the floor
+    vm.prank(manager);
+    adapter.fundInterest(100_000 ether); // eats through the 3k floor
+    assertEq(adapter.idleBalance(), 0, "interest may drain down to zero");
+    assertLt(adapter.idleBalance(), adapter.hardFloor(), "floor pierced only via interest");
+  }
+
+  /**
+   * INV-3 (adapter cannot over-fund, PRD §4.6 net settlement): pushing more than the
+   * pool's pending obligation reverts even when the adapter holds the cash.
+   */
+  function test_inv3_finishRevertsWhenQuotaExceedsPending() public {
+    _depositFlex(alice, 100_000 ether);
+    vm.prank(alice);
+    flex.requestWithdraw(40_000 ether); // pending 40k
+
+    // 90k <= available(97k) clears the reserve guard, but exceeds the 40k pending
+    vm.prank(bot);
+    vm.expectRevert("quota exceeds pending");
+    adapter.finishFlexWithdraw(90_000 ether);
+  }
+
+  /**
+   * INV-4 (floor base restoration, PRD §14.4 conservative sizing): requesting a
+   * withdrawal burns LP but the funds have not left yet, so totalPendingWithdraw
+   * must backfill the floor base — the hard floor does not drop.
+   */
+  function test_inv4_floorBaseRestoredAfterRequest() public {
+    _depositFlex(alice, 100_000 ether);
+    uint256 floorBefore = adapter.hardFloor();
+
+    vm.prank(alice);
+    flex.requestWithdraw(50_000 ether);
+    uint256 floorAfter = adapter.hardFloor();
+
+    assertEq(floorAfter, floorBefore, "hard floor must not drop when request only burns LP");
+    assertEq(floorAfter, 3_000 ether, "3% of the 100k book is preserved");
+  }
+
+  /* ---- helper ---- */
+  function _assertConservation() internal view {
+    uint256 lhs = usdt.balanceOf(address(adapter)) + usdt.balanceOf(address(flex)) + usdt.balanceOf(surfinWallet);
+    uint256 rhs = flex.totalPrincipal() + flex.totalPendingWithdraw();
+    assertEq(lhs, rhs, "USDT conservation broken");
+  }
+}

--- a/test/surfin/SurfinInvariant.t.sol
+++ b/test/surfin/SurfinInvariant.t.sol
@@ -65,7 +65,7 @@ contract FlexInvariantHandler is Test {
     for (uint256 i = 0; i < reqs.length; i++) {
       if (reqs[i].batchId <= flex.confirmedBatchId()) {
         vm.prank(a);
-        flex.claimWithdraw(a, i);
+        flex.claimWithdraw(a, i, reqs[i].amount);
         return;
       }
     }
@@ -77,7 +77,7 @@ contract FlexInvariantHandler is Test {
     for (uint256 i = 0; i < reqs.length; i++) {
       if (reqs[i].batchId > flex.confirmedBatchId()) {
         vm.prank(a);
-        flex.cancelWithdraw(i);
+        flex.cancelWithdraw(i, reqs[i].amount);
         return;
       }
     }
@@ -169,7 +169,7 @@ contract SurfinInvariant is SurfinTestBase {
     _assertConservation();
 
     vm.prank(alice);
-    flex.claimWithdraw(alice, 0); // alice +50k, flex 0, pending 0
+    flex.claimWithdraw(alice, 0, 50_000 ether); // alice +50k, flex 0, pending 0
     _assertConservation();
 
     // remaining idle can be deployed down to the (now smaller) floor

--- a/test/surfin/SurfinInvariant.t.sol
+++ b/test/surfin/SurfinInvariant.t.sol
@@ -133,14 +133,34 @@ contract SurfinInvariant is SurfinTestBase {
   }
 
   /* ---- INV-3: the adapter never over-pushes past the pool's real obligation ---- */
-  /// @dev NOTE: `withdrawQuota <= totalPendingWithdraw` is deliberately NOT a global
-  ///      invariant. It is enforced only on funding pushes (finishWithdraw with
-  ///      amount > 0). A partially-funded batch that is then cancelled can strand
-  ///      surplus quota (quota > pending) until a later batch or a 0-amount tick
-  ///      consumes it — see finishWithdraw's comment and the existing
-  ///      SurfinAdapterGuard cancel-after-partial-fund regression. The always-true
-  ///      safety property is pool solvency (invariant_flexPoolSolvent above); the
-  ///      per-push guard is pinned by test_inv3_finishRevertsWhenQuotaExceedsPending.
+  /// @dev A global invariant once the bound is the UNCONFIRMED obligation rather than
+  ///      totalPendingWithdraw. The wider bound counts confirmed-but-unclaimed payouts
+  ///      whose cash already sits in the pool, so a partial fund followed by a
+  ///      cancellation could strand surplus quota behind that mask until the last claim
+  ///      exposed it. Cancellation now returns the orphan on the spot, so the property
+  ///      survives every action the handler can take.
+  ///
+  ///      Caveat: adminTopUp (M03) deliberately bypasses the cap to cover a shortfall on
+  ///      an impaired fund, so it can leave quota above this bound by design. The handler
+  ///      does not drive it; if it is ever added, exclude it here.
+  function invariant_quotaNeverExceedsUnconfirmedObligation() public view {
+    assertLe(
+      flex.withdrawQuota(),
+      flex.totalPendingWithdraw() - flex.totalConfirmedUnclaimed(),
+      "quota exceeds the obligation still awaiting adapter cash"
+    );
+  }
+
+  /// @dev the on-chain counter must always equal the payouts actually sitting confirmed in
+  ///      the queue — pins the += in _confirmBatches against the -= in
+  ///      _consumeConfirmedWithdraw, the pair the guard above depends on.
+  function invariant_confirmedUnclaimedMatchesQueue() public view {
+    assertEq(
+      flex.totalConfirmedUnclaimed(),
+      handler.confirmedUnclaimed(),
+      "totalConfirmedUnclaimed drifted from the queue"
+    );
+  }
 
   /* ---- INV-2: the on-chain hard floor is never paid out by withdrawal flows ---- */
   function invariant_floorNeverBreached() public view {

--- a/test/surfin/SurfinJourney.t.sol
+++ b/test/surfin/SurfinJourney.t.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./SurfinTestBase.sol";
+
+/**
+ * Test group 4 — end-to-end user journeys (closest to the PRD §11 personas).
+ *
+ * Each journey walks a persona across contract boundaries (pool -> adapter ->
+ * distributor) to prove the pieces connect, not just that each unit works:
+ *  - Alice: flex full cycle, principal via the batch queue, interest via the distributor
+ *  - Bob:   locked auto-renew, capped at exactly one term
+ *  - Charlie: early redeem takes a principal haircut end-to-end
+ *  - Eve:   matured principal exits via BOT batching + weekly settleRecall, cap-exempt
+ *  - Frank: an oversized withdrawal is forced to split across UTC days by the cap
+ */
+contract SurfinJourneyTest is SurfinTestBase {
+  address eve = makeAddr("eve");
+  address frank = makeAddr("frank");
+
+  /* ------------------------------- Alice ------------------------------- */
+
+  function test_journey_Alice_flexFullCycle() public {
+    // 1. deposit — funds custody at the adapter
+    _depositFlex(alice, 10_000 ether);
+    assertEq(usdt.balanceOf(address(adapter)), 10_000 ether);
+
+    // 2. manager deploys the deployable surplus to Surfin
+    uint256 deployable = adapter.maxDeployToSurfin(); // 10k - 300 floor = 9,700
+    vm.prank(manager);
+    adapter.deployToSurfin(deployable);
+
+    // 3. alice requests her full principal back
+    vm.prank(alice);
+    flex.requestWithdraw(10_000 ether);
+
+    // 4. Surfin returns cash; BOT funds the batch
+    _fundAdapter(10_000 ether);
+    vm.prank(bot);
+    adapter.finishFlexWithdraw(10_000 ether);
+
+    // 5. claim principal to the wallet
+    vm.prank(alice);
+    flex.claimWithdraw(alice, 0);
+    assertEq(usdt.balanceOf(alice), 10_000 ether, "principal fully returned via the queue");
+
+    // 6. interest is separate: funded to, and claimed from, the distributor
+    _fundAdapter(100 ether);
+    vm.prank(manager);
+    adapter.fundInterest(100 ether);
+    _publishRoot(_leaf(alice, 100 ether));
+    bytes32[] memory empty = new bytes32[](0);
+    distributor.claim(alice, 100 ether, empty);
+
+    assertEq(usdt.balanceOf(alice), 10_100 ether, "principal + interest, interest via the distributor");
+  }
+
+  /* -------------------------------- Bob -------------------------------- */
+
+  function test_journey_Bob_lockedRenewCappedAtOneTerm() public {
+    vm.warp(1_000_000);
+    _setCohort(1, 90, block.timestamp + 1 days, block.timestamp + 91 days, true);
+    _depositLocked(bob, 1, 50_000 ether, true); // auto-renew ON
+
+    // term 1 matures -> BOT renews into term 2 (auto-renew forced off)
+    vm.warp(block.timestamp + 92 days);
+    _setCohort(2, 90, block.timestamp + 1 days, block.timestamp + 91 days, true);
+    vm.prank(bot);
+    locked.renewPosition(bob, 0, 2);
+
+    // term 2 matures -> a second renewal is refused (one-term cap)
+    vm.warp(block.timestamp + 92 days);
+    _setCohort(3, 90, block.timestamp + 1 days, block.timestamp + 91 days, true);
+    vm.prank(bot);
+    vm.expectRevert("auto renew off");
+    locked.renewPosition(bob, 1, 3);
+
+    // instead the principal exits via a normal matured withdrawal
+    vm.prank(bob);
+    locked.requestMaturityWithdraw(1);
+    assertEq(locked.totalPendingWithdraw(), 50_000 ether, "principal exits after exactly one renewal");
+  }
+
+  /* ------------------------------ Charlie ------------------------------ */
+
+  function test_journey_Charlie_earlyRedeemPrincipalHaircut() public {
+    vm.warp(1_000_000);
+    _setCohort(1, 90, block.timestamp + 1 days, block.timestamp + 91 days, true);
+    _depositLocked(charlie, 1, 50_000 ether, false);
+
+    vm.warp(block.timestamp + 15 days); // inside the penalty window
+    vm.prank(charlie);
+    locked.requestEarlyRedeem(0, 50_000 ether); // payout 49,600
+
+    _fundAdapter(50_000 ether);
+    vm.prank(bot);
+    adapter.finishLockedWithdraw(49_600 ether);
+    vm.prank(charlie);
+    locked.claimWithdraw(charlie, 0);
+
+    assertEq(usdt.balanceOf(charlie), 49_600 ether, "principal minus the 0.8% early-redeem penalty");
+  }
+
+  /* -------------------------------- Eve -------------------------------- */
+
+  function test_journey_Eve_maturityViaSettleRecall() public {
+    vm.warp(1_000_000);
+    vm.prank(manager);
+    locked.setDailyLimit(200_000 ether); // matured withdrawal must ignore this cap
+    _setCohort(1, 90, block.timestamp + 1 days, block.timestamp + 91 days, true);
+    _depositLocked(eve, 1, 300_000 ether, false); // larger than the daily cap
+
+    vm.warp(block.timestamp + 92 days);
+
+    // BOT queues eve's matured principal on her behalf (settlement-day job)
+    address[] memory users = new address[](1);
+    uint256[] memory posIds = new uint256[](1);
+    users[0] = eve;
+    posIds[0] = 0;
+    vm.prank(bot);
+    locked.batchRequestMaturityWithdraw(users, posIds);
+    assertEq(locked.totalPendingWithdraw(), 300_000 ether, "full principal queued despite the 200k cap");
+
+    // the weekly recall settlement covers the locked queue out of the settlement funds
+    _settleRecall(300_000 ether, 300_000 ether, 0, 0);
+    assertEq(locked.confirmedBatchId(), 1, "settlement funds confirmed the matured batch");
+
+    vm.prank(eve);
+    locked.claimWithdraw(eve, 0);
+    assertEq(usdt.balanceOf(eve), 300_000 ether, "full principal, no penalty, cap-exempt");
+  }
+
+  /* ------------------------------- Frank ------------------------------- */
+
+  function test_journey_Frank_largeWithdrawSplitAcrossDays() public {
+    vm.prank(manager);
+    flex.setDailyLimit(200_000 ether);
+    _depositFlex(frank, 800_000 ether);
+
+    // day 1: 200k clears, anything more the same day reverts
+    vm.prank(frank);
+    flex.requestWithdraw(200_000 ether);
+    vm.prank(frank);
+    vm.expectRevert("exceeds daily limit");
+    flex.requestWithdraw(1);
+
+    // the remaining 600k has to spread across the next three UTC days
+    for (uint256 i = 0; i < 3; i++) {
+      vm.warp(block.timestamp + 1 days);
+      vm.prank(frank);
+      flex.requestWithdraw(200_000 ether);
+    }
+
+    assertEq(flex.balanceOf(frank), 0, "all 800k queued over four days");
+    assertEq(flex.totalPendingWithdraw(), 800_000 ether);
+  }
+}

--- a/test/surfin/SurfinJourney.t.sol
+++ b/test/surfin/SurfinJourney.t.sol
@@ -41,7 +41,7 @@ contract SurfinJourneyTest is SurfinTestBase {
 
     // 5. claim principal to the wallet
     vm.prank(alice);
-    flex.claimWithdraw(alice, 0);
+    flex.claimWithdraw(alice, 0, 10_000 ether);
     assertEq(usdt.balanceOf(alice), 10_000 ether, "principal fully returned via the queue");
 
     // 6. interest is separate: funded to, and claimed from, the distributor
@@ -96,7 +96,7 @@ contract SurfinJourneyTest is SurfinTestBase {
     vm.prank(bot);
     adapter.finishLockedWithdraw(49_600 ether);
     vm.prank(charlie);
-    locked.claimWithdraw(charlie, 0);
+    locked.claimWithdraw(charlie, 0, 49_600 ether);
 
     assertEq(usdt.balanceOf(charlie), 49_600 ether, "principal minus the 0.8% early-redeem penalty");
   }
@@ -126,7 +126,7 @@ contract SurfinJourneyTest is SurfinTestBase {
     assertEq(locked.confirmedBatchId(), 1, "settlement funds confirmed the matured batch");
 
     vm.prank(eve);
-    locked.claimWithdraw(eve, 0);
+    locked.claimWithdraw(eve, 0, 300_000 ether);
     assertEq(usdt.balanceOf(eve), 300_000 ether, "full principal, no penalty, cap-exempt");
   }
 

--- a/test/surfin/SurfinTestBase.sol
+++ b/test/surfin/SurfinTestBase.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../src/surfin/SurfinAdapter.sol";
+import "../../src/surfin/FlexEarnPool.sol";
+import "../../src/surfin/LockedEarnPool.sol";
+import "../../src/surfin/InterestDistributor.sol";
+import "../../src/mock/MockERC20.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/**
+ * Shared fixture for the Surfin Credit Fund test suite. Wires the full system the
+ * way the deploy script does — flex pool, locked pool, adapter, and the cumulative
+ * Merkle interest distributor — so every suite (invariants, conflicts, module unit
+ * tests, and end-to-end journeys) inherits one consistent setup.
+ *
+ * Deployment mirrors the existing surfin regression suites
+ * (SurfinAdapterGuard / SurfinAdapterSettleRecall): ERC1967 proxies, the same
+ * admin/manager/pauser/bot roles, and 18-decimal USDT.
+ */
+abstract contract SurfinTestBase is Test {
+  MockERC20 usdt;
+  SurfinAdapter adapter;
+  FlexEarnPool flex;
+  LockedEarnPool locked;
+  InterestDistributor distributor;
+
+  address admin = makeAddr("admin");
+  address manager = makeAddr("manager");
+  address pauser = makeAddr("pauser");
+  address bot = makeAddr("bot");
+  address surfinWallet = makeAddr("surfinWallet");
+  address feeReceiver = makeAddr("feeReceiver");
+
+  address alice = makeAddr("alice");
+  address bob = makeAddr("bob");
+  address charlie = makeAddr("charlie");
+
+  uint256 constant FLOOR_RATE = 3e16; // 3% hard floor
+
+  function setUp() public virtual {
+    usdt = new MockERC20("USDT", "USDT");
+
+    FlexEarnPool flexImpl = new FlexEarnPool();
+    LockedEarnPool lockedImpl = new LockedEarnPool();
+    SurfinAdapter adapterImpl = new SurfinAdapter(address(usdt));
+    InterestDistributor distImpl = new InterestDistributor();
+
+    flex = FlexEarnPool(
+      address(
+        new ERC1967Proxy(
+          address(flexImpl),
+          abi.encodeWithSelector(
+            flexImpl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            bot,
+            address(usdt),
+            address(this),
+            "Flex",
+            "FLEX"
+          )
+        )
+      )
+    );
+    locked = LockedEarnPool(
+      address(
+        new ERC1967Proxy(
+          address(lockedImpl),
+          abi.encodeWithSelector(
+            lockedImpl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            bot,
+            address(usdt),
+            address(this),
+            "Locked",
+            "LOCK"
+          )
+        )
+      )
+    );
+    adapter = SurfinAdapter(
+      address(
+        new ERC1967Proxy(
+          address(adapterImpl),
+          abi.encodeWithSelector(
+            adapterImpl.initialize.selector,
+            admin,
+            manager,
+            pauser,
+            bot,
+            address(flex),
+            address(locked),
+            surfinWallet
+          )
+        )
+      )
+    );
+    // interest distributor: note the initialize order (admin, manager, bot, pauser,
+    // funder, token); the funder must be the adapter, which is the only caller of
+    // notifyReward.
+    distributor = InterestDistributor(
+      address(
+        new ERC1967Proxy(
+          address(distImpl),
+          abi.encodeWithSelector(
+            distImpl.initialize.selector,
+            admin,
+            manager,
+            bot,
+            pauser,
+            address(adapter),
+            address(usdt)
+          )
+        )
+      )
+    );
+
+    vm.startPrank(admin);
+    flex.setAdapter(address(adapter));
+    locked.setAdapter(address(adapter));
+    vm.stopPrank();
+
+    vm.startPrank(manager);
+    adapter.setInterestDistributor(address(distributor));
+    adapter.setFeeReceiver(feeReceiver);
+    vm.stopPrank();
+  }
+
+  /* ---- helpers ---- */
+
+  /// @dev flex deposit: mint, approve, deposit; funds land in the adapter.
+  function _depositFlex(address who, uint256 amount) internal {
+    usdt.mint(who, amount);
+    vm.startPrank(who);
+    usdt.approve(address(flex), amount);
+    flex.deposit(amount, who);
+    vm.stopPrank();
+  }
+
+  /// @dev create/enable a cohort (BOT-gated).
+  function _setCohort(
+    uint256 cohortId,
+    uint256 termDays,
+    uint256 depositDeadline,
+    uint256 maturityTime,
+    bool enabled
+  ) internal {
+    vm.prank(bot);
+    locked.setCohort(cohortId, termDays, depositDeadline, maturityTime, enabled);
+  }
+
+  /// @dev locked deposit into an existing cohort; funds land in the adapter.
+  function _depositLocked(address who, uint256 cohortId, uint256 amount, bool autoRenew) internal {
+    usdt.mint(who, amount);
+    vm.startPrank(who);
+    usdt.approve(address(locked), amount);
+    locked.deposit(cohortId, amount, who, autoRenew);
+    vm.stopPrank();
+  }
+
+  /// @dev drop raw USDT onto the adapter to emulate recalled/idle cash without
+  ///      touching the deployed book value (settleRecall path is tested separately).
+  function _fundAdapter(uint256 amount) internal {
+    usdt.mint(address(adapter), amount);
+  }
+
+  /// @dev manager settleRecall wrapper (mint + approve + call).
+  function _settleRecall(
+    uint256 recalledAmount,
+    uint256 lockedCoverAmount,
+    uint256 feeAmount,
+    uint256 bookValue
+  ) internal {
+    usdt.mint(manager, recalledAmount);
+    vm.startPrank(manager);
+    usdt.approve(address(adapter), recalledAmount);
+    adapter.settleRecall(recalledAmount, lockedCoverAmount, feeAmount, bookValue);
+    vm.stopPrank();
+  }
+
+  /// @dev single-leaf cumulative Merkle root for the distributor (root == leaf, empty proof).
+  function _leaf(address account, uint256 totalAmount) internal view returns (bytes32) {
+    return keccak256(abi.encode(block.chainid, address(distributor), distributor.claim.selector, account, totalAmount));
+  }
+
+  /// @dev publish a single-leaf root through the two-step timelocked flow.
+  function _publishRoot(bytes32 root) internal {
+    vm.prank(bot);
+    distributor.setPendingMerkleRoot(root);
+    vm.warp(block.timestamp + distributor.waitingPeriod());
+    vm.prank(bot);
+    distributor.acceptMerkleRoot();
+  }
+}


### PR DESCRIPTION
## Overview

Introduces the full on-chain infrastructure for the **Surfin Credit Fund** — a two-product (flex demand + locked term) USDT yield fund that deploys user capital to Surfin's off-chain fixed-income strategies. All fund routing, buffer management, and interest distribution live in this PR.

---

## New Contracts

### `src/surfin/CreditFundBase.sol`
Abstract base for both pool types. Provides:
- **Daily batch-queue withdrawal** — `requestWithdraw` enqueues into a `batchId` keyed by day; `finishWithdraw` (adapter-only) confirms whole batches in order using a `withdrawQuota` accumulator; `claimWithdraw` requires `batchId ≤ confirmedBatchId`.
- **Per-address daily submit limit** — `dailyLimit` / `dailySubmitted[day][user]`.
- **Deposit wind-down switch** — `depositPaused` blocks new deposits and locked early-redemptions while keeping withdrawal / claim paths open.
- **Whitelist, min-deposit, emergency rescue** (admin-only).

### `src/surfin/FlexEarnPool.sol`
Demand (flex) product. Mints 1:1 LP on deposit; funds forwarded directly to `SurfinAdapter`. Inherits `CreditFundBase` batch queue.

### `src/surfin/LockedEarnPool.sol`
Term (locked) product using an **issuance-cohort model**:
- `Cohort{termDays, baseQuote, depositDeadline, interestStartTime, maturityTime, enabled}` — dates injected by Manager with on-chain guardrails (`MAX_START_DELAY = 7 d`, `MAX_ALIGN_WINDOW = 31 d`).
- `Position{principal, cohortId, baseQuote (snapshot), autoRenew, closed}` — no per-position timestamps stored.
- `requestEarlyRedeem` supports **partial** redemption; penalty anchored at `interestStartTime` (not deposit time).
- `requestMaturityWithdraw` reads maturity from the cohort.
- `renewPosition` (BOT-only) for auto-renewal into a new cohort.

### `src/surfin/InterestDistributor.sol`
Cumulative Merkle interest distributor (modelled on `LendingRewardsDistributorV2`):
- `notifyReward(token, amount)` — `onlyRole(FUNDER)` (granted to SurfinAdapter); pulls USDT from adapter into distributor.
- Two-step time-locked root update: `setPendingMerkleRoot` → wait ≥ `waitingPeriod` (default 1 day, min 6 h) → `acceptMerkleRoot`; Manager can `revokePendingMerkleRoot` inside the window.
- `claim(account, token, totalAmount, proof)` — pays `totalAmount − claimed[account][token]` (cumulative, replay-safe). Supports multiple reward tokens (`claimed` is `mapping(address ⇒ mapping(address ⇒ uint256))`).

### `src/surfin/SurfinAdapter.sol`
Central fund router — holds all USDT:
- **Deploy / recall** — `deployToSurfin` (weekly cap, no deploy in same cycle as recall) → `OTCManager.swapToken` → Surfin OTC wallet. `repayFromSurfin` decrements `deployedToSurfin`.
- **Buffer math** — `flexBufferRate 15% / flexFloorRate 3%`; `lockedBufferRate 5% / lockedFloorRate 1.5%`. `maxDeployToSurfin = freeIdle − pendingWithdraw − bufferTargets`. `instantWithdrawable = freeIdle − pendingWithdraw − floors`.
- **Settlement reserve** — `allocateToSettlement` earmarks matured locked principal (never re-deployable); `releaseSettlement` routes it to `lockedPool.finishWithdraw`.
- **Interest funding** — `fundInterest` → approve + `InterestDistributor.notifyReward`.
- **Emergency controls** — inherits `PausableUpgradeable`; `pause` (PAUSER) blocks outbound flows (`deployToSurfin`, vault deposits); repay / finishWithdraw / claimFee remain open.

### `src/surfin/OTCManager.sol`
Gateway to Surfin's off-chain OTC desk. `swapToken` (adapter-only) transfers USDT to the OTC wallet; `transferToAdapter` (BOT) pulls repayments back.

### Interfaces
- `src/surfin/interface/ICreditFundPool.sol`
- `src/surfin/interface/IInterestDistributor.sol`
- `src/surfin/interface/IOTCManager.sol`
- `src/surfin/interface/IAsyncVault.sol` (PSM / Venus channel — reserved for future use)

### Deploy Script
- `script/surfin/deploy_surfin.s.sol` — deploys all five proxies (FlexEarnPool, LockedEarnPool, OTCManager, InterestDistributor, SurfinAdapter) and wires roles / cross-references.

---

## Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| Batch-queue withdrawal | Funds live off-chain (Surfin); BOT injects a single lump sum per day. Batching turns N-user confirmation into a single monotonic `confirmedBatchId` advance — O(1) per user claim, no per-user loops. |
| Cohort model for locked pool | Old per-position `startTime = block.timestamp` caused rolling expiry and wrong penalty anchor. Cohort dates are injected by Manager so all depositors in a tranche share the same settlement day. |
| Merkle interest distribution (off-pool) | Interest is computed off-chain. Pushing a cumulative root avoids per-block on-chain accrual and lets a single distributor serve both pool types with any reward token. |
| `depositPaused` wind-down switch | Separate from the global `pause`; blocks new capital inflows and early redemptions during stress/wind-down without freezing pending withdrawal claims. |
| `freeIdle = idleBalance − settlementReserve − accruedFee` | Prevents earmarked funds (matured principal, Lista fee) from being counted as deployable or user-payable liquidity. |

---

## Testing

```bash
# compile src only (foundry-upgrades submodule not required)
forge build --skip '*.s.sol' --skip test

# compile deploy script separately
forge build script/surfin/deploy_surfin.s.sol
```

All source contracts compile without errors or warnings.

---

## Checklist

- [x] New contracts compile (`forge build --skip '*.s.sol' --skip test`)
- [x] Deploy script compiles
- [x] No on-chain interest accrual — all yield computed off-chain
- [x] `claimed[user][token]` double-keyed (multi-token safe, follows `LendingRewardsDistributorV2`)
- [x] Cohort guardrails: `depositDeadline ≤ interestStartTime ≤ depositDeadline + 7 d`, `maturityTime ∈ [interestStartTime + termDays, + 31 d]`
- [x] Partial early-redemption supported in `LockedEarnPool`
- [x] UUPS upgrade pattern (`_disableInitializers` in constructor, `_authorizeUpgrade` admin-only)
- [x] No `console.log` / `console.error` in production code