### PR TITLE
feat(oracle): generic wNLP price feed + wNLP-S5B (nSPCXB) deployment

### DIFF
--- a/script/oracle/deployWNLPSPCXBPriceFeed.sol
+++ b/script/oracle/deployWNLPSPCXBPriceFeed.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Script.sol";
+
+import { wNLPPriceFeed } from "@src/oracle/wNLPPriceFeed.sol";
+import "@src/oracle/interfaces/OracleInterface.sol";
+
+/**
+ * @title DeployWNLPSPCXBPriceFeed
+ * @notice Deploys the wNLP-S5B/USD price feed used by the nSPCXB / SPCXB
+ * whitelist market. nSPCXB is the product name for the wNLP-S5B wrapper
+ * (on-chain symbol wNLP-S5B, name Wrapped NLP: S5B).
+ *
+ * Verified on BSC mainnet:
+ *   wNLP-S5B.underlying()       = SPCXB 0xbe9D...03E1
+ *   wNLP-S5B.nlp()              = NLP-S5B 0x4EE1C93E...4939
+ *   wNLP-S5B.getNlpByWnlp(1e18) ~ 1.0151 (wrapper accrues, rate > 1)
+ *   resilientOracle.peek(SPCXB) ~ 115 USD (8 decimals)
+ *
+ * After deployment the feed still has to be registered as the MAIN oracle of
+ * wNLP-S5B on the ResilientOracle (setTokenConfigs, Ops multi-sig) and a
+ * BoundValidator entry added, before peek(wNLP-S5B) resolves. Until then
+ * Moolah.createMarket reverts, because it peeks both market tokens.
+ *
+ * Run with:
+ *   forge script script/oracle/deployWNLPSPCXBPriceFeed.sol:DeployWNLPSPCXBPriceFeed \
+ *     --rpc-url bsc --private-key $DEPLOYER_PRIVATE_KEY --broadcast --verify -vvvv
+ */
+contract DeployWNLPSPCXBPriceFeed is Script {
+  // Lista ResilientOracle (BSC mainnet)
+  address constant RESILIENT_ORACLE = 0xf3afD82A4071f272F403dC176916141f44E6c750;
+  // wNLP-S5B wrapper == nSPCXB, the market collateral
+  address constant WNLP_S5B = 0xF27760F7b431aD8cAeE0f4E3062E6140b14E0eBC;
+  // SPCXB, the wrapper's underlying and the market loan token
+  address constant SPCXB = 0xbe9D156892E55e7154BcD3cB0FEA677F9D3103E1;
+
+  string constant DESCRIPTION = "wNLP-S5B/USD Price Feed";
+
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer:", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    wNLPPriceFeed feed = new wNLPPriceFeed(RESILIENT_ORACLE, WNLP_S5B, SPCXB, DESCRIPTION);
+
+    vm.stopBroadcast();
+
+    console.log("wNLPPriceFeed (wNLP-S5B) deployed ->", address(feed));
+    console.log("  SPCXB (1e8):", OracleInterface(RESILIENT_ORACLE).peek(SPCXB));
+    console.log("  wNLP-S5B (1e8):", uint256(feed.latestAnswer()));
+  }
+}

--- a/src/oracle/interfaces/OracleInterface.sol
+++ b/src/oracle/interfaces/OracleInterface.sol
@@ -35,3 +35,7 @@ interface BoundValidatorInterface {
     uint256 anchorPrice
   ) external view returns (bool);
 }
+
+interface IWNLP {
+  function getNlpByWnlp(uint256 amount) external view returns (uint256);
+}

--- a/src/oracle/wNLPPriceFeed.sol
+++ b/src/oracle/wNLPPriceFeed.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "./interfaces/OracleInterface.sol";
+import "./libraries/FullMath.sol";
+
+/**
+ * @title wNLPPriceFeed
+ * @author Lista
+ * @notice Generic Chainlink-shaped price feed for any Native wNLP-* wrapper.
+ * Reads the wNLP/underlying exchange rate from the wNLP contract and the
+ * underlying/USD price from the Lista ResilientOracle, returning wNLP/USD in 8
+ * decimals.
+ * @dev Parameterised form of the hardcoded wNLP-USDT feed: the wNLP token, its
+ * underlying and the description are all constructor immutables, so a single
+ * implementation serves every wNLP-* token instead of one file per token.
+ * Exposes an 8-decimal AggregatorV3Interface so it can be registered as the
+ * MAIN oracle of the wNLP token on the ResilientOracle, which reads it via
+ * latestRoundData(), mirroring {AtlasOracleAdaptor} and {LisAsterPriceFeed}.
+ *
+ * Staleness note: the underlying leg is bounded by the underlying's own
+ * timeDeltaTolerance inside the ResilientOracle, and peek reverts on an invalid
+ * price. The wNLP rate carries no timestamp, so it cannot be freshness-checked
+ * here; a frozen rate would be reported as current. Monitor the rate off-chain.
+ */
+contract wNLPPriceFeed is AggregatorV3Interface {
+  /// @notice Lista ResilientOracle providing the underlying USD price (8 decimals) via peek.
+  OracleInterface public immutable resilientOracle;
+  /// @notice wNLP-* wrapper token (non-upgradeable), source of the wNLP/underlying rate.
+  IWNLP public immutable wNLP;
+  /// @notice The wrapper's underlying token, priced by the ResilientOracle.
+  address public immutable underlying;
+
+  string private _description;
+
+  /**
+   * @param _resilientOracle Lista ResilientOracle address.
+   * @param _wNLP wNLP-* wrapper token address.
+   * @param _underlying The wrapper's underlying token address.
+   * @param description_ Feed description, e.g. "wNLP-S5B/USD Price Feed".
+   */
+  constructor(address _resilientOracle, address _wNLP, address _underlying, string memory description_) {
+    require(
+      _resilientOracle != address(0) && _wNLP != address(0) && _underlying != address(0),
+      "wNLPPriceFeed/zero-address"
+    );
+    resilientOracle = OracleInterface(_resilientOracle);
+    wNLP = IWNLP(_wNLP);
+    underlying = _underlying;
+    _description = description_;
+  }
+
+  function decimals() external pure returns (uint8) {
+    return 8;
+  }
+
+  /// @dev `view` rather than `pure` because the description is set per deployment.
+  function description() external view returns (string memory) {
+    return _description;
+  }
+
+  function version() external pure returns (uint256) {
+    return 1;
+  }
+
+  function latestAnswer() external view returns (int256) {
+    return int256(_price());
+  }
+
+  function getRoundData(
+    uint80 _roundId
+  )
+    external
+    view
+    returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+  {
+    return (_roundId, int256(_price()), block.timestamp, block.timestamp, _roundId);
+  }
+
+  function latestRoundData()
+    external
+    view
+    returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+  {
+    uint256 timestamp = block.timestamp;
+    uint80 round = uint80(timestamp);
+    return (round, int256(_price()), timestamp, timestamp, round);
+  }
+
+  /**
+   * @dev Multiply the wNLP/underlying rate (18 decimals) by the underlying/USD
+   * price (8 decimals) and scale back down by 1e18, yielding wNLP/USD in 8
+   * decimals. FullMath.mulDiv avoids intermediate overflow.
+   */
+  function _price() internal view returns (uint256) {
+    uint256 rate = wNLP.getNlpByWnlp(1e18);
+    require(rate > 0, "wNLPPriceFeed/rate-not-valid");
+    uint256 underlyingPrice = resilientOracle.peek(underlying);
+    return FullMath.mulDiv(underlyingPrice, rate, 1e18);
+  }
+}

--- a/test/oracle/wNLPPriceFeed.t.sol
+++ b/test/oracle/wNLPPriceFeed.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import { wNLPPriceFeed } from "@src/oracle/wNLPPriceFeed.sol";
+import "@src/oracle/interfaces/OracleInterface.sol";
+
+/**
+ * @dev Fork tests for the generic wNLP price feed.
+ *
+ * The wNLP-S5B case (nSPCXB, collateral of the nSPCXB / SPCXB whitelist market)
+ * is the new deployment. The wNLP-USDT case reproduces the already deployed
+ * hardcoded wNLP-USDT feed to prove the generic contract is behaviour-equivalent
+ * to that precedent.
+ */
+contract wNLPPriceFeedTest is Test {
+  address constant RESILIENT_ORACLE = 0xf3afD82A4071f272F403dC176916141f44E6c750;
+
+  // wNLP-S5B == nSPCXB, underlying SPCXB
+  address constant WNLP_S5B = 0xF27760F7b431aD8cAeE0f4E3062E6140b14E0eBC;
+  address constant SPCXB = 0xbe9D156892E55e7154BcD3cB0FEA677F9D3103E1;
+
+  // Already-live precedent: wNLP-USDT, underlying USDT
+  address constant WNLP_USDT = 0xEA5FF211eF700DccC521a1e6501C9fe1B95D8EE7;
+  address constant USDT = 0x55d398326f99059fF775485246999027B3197955;
+  // The deployed hardcoded feed for wNLP-USDT
+  address constant DEPLOYED_WNLP_USDT_FEED = 0xf86155a27B5Cd958732A29829d80017727dE4262;
+
+  function setUp() public {
+    vm.createSelectFork("https://bsc-dataseed.binance.org");
+  }
+
+  function _deploy(address wnlp, address underlying, string memory desc) internal returns (wNLPPriceFeed) {
+    return new wNLPPriceFeed(RESILIENT_ORACLE, wnlp, underlying, desc);
+  }
+
+  // ---------------------------------------------------------------- wNLP-S5B
+
+  function test_S5B_priceMatchesRateTimesUnderlying() public {
+    wNLPPriceFeed feed = _deploy(WNLP_S5B, SPCXB, "wNLP-S5B/USD Price Feed");
+
+    uint256 rate = IWNLP(WNLP_S5B).getNlpByWnlp(1e18);
+    uint256 underlyingPrice = OracleInterface(RESILIENT_ORACLE).peek(SPCXB);
+    assertGt(rate, 0, "rate must be non-zero");
+    assertGt(underlyingPrice, 0, "underlying price must be non-zero");
+
+    (, int256 answer, , uint256 updatedAt, ) = feed.latestRoundData();
+
+    console.log("wNLP-S5B rate (1e18):", rate);
+    console.log("SPCXB price (1e8)   :", underlyingPrice);
+    console.log("wNLP-S5B price (1e8):", uint256(answer));
+
+    assertEq(uint256(answer), (underlyingPrice * rate) / 1e18, "price != underlying * rate");
+    assertEq(uint256(feed.latestAnswer()), uint256(answer), "latestAnswer != latestRoundData");
+    assertEq(updatedAt, block.timestamp, "updatedAt should be block.timestamp");
+  }
+
+  /// @dev The wrapper accrues, so wNLP is worth at least the underlying, not less.
+  function test_S5B_priceAboveUnderlying() public {
+    wNLPPriceFeed feed = _deploy(WNLP_S5B, SPCXB, "wNLP-S5B/USD Price Feed");
+    uint256 underlyingPrice = OracleInterface(RESILIENT_ORACLE).peek(SPCXB);
+    assertGe(uint256(feed.latestAnswer()), underlyingPrice, "wNLP should be >= underlying");
+  }
+
+  function test_S5B_metadata() public {
+    wNLPPriceFeed feed = _deploy(WNLP_S5B, SPCXB, "wNLP-S5B/USD Price Feed");
+    assertEq(feed.decimals(), 8);
+    assertEq(feed.version(), 1);
+    assertEq(feed.description(), "wNLP-S5B/USD Price Feed");
+    assertEq(address(feed.wNLP()), WNLP_S5B);
+    assertEq(feed.underlying(), SPCXB);
+    assertEq(address(feed.resilientOracle()), RESILIENT_ORACLE);
+  }
+
+  // ------------------------------------------- equivalence with the precedent
+
+  /// @dev Same inputs must produce the same output as the deployed hardcoded feed.
+  function test_USDT_matchesDeployedHardcodedFeed() public {
+    wNLPPriceFeed generic = _deploy(WNLP_USDT, USDT, "wNLP-USDT/USD Price Feed");
+
+    (, int256 genericAnswer, , , ) = generic.latestRoundData();
+    (, int256 deployedAnswer, , , ) = AggregatorV3Interface(DEPLOYED_WNLP_USDT_FEED).latestRoundData();
+
+    console.log("generic  wNLP-USDT (1e8):", uint256(genericAnswer));
+    console.log("deployed wNLP-USDT (1e8):", uint256(deployedAnswer));
+
+    assertEq(genericAnswer, deployedAnswer, "generic feed must match deployed feed");
+    assertEq(generic.decimals(), 8);
+  }
+
+  // ---------------------------------------------------------------- negatives
+
+  function test_revertsOnZeroResilientOracle() public {
+    vm.expectRevert("wNLPPriceFeed/zero-address");
+    new wNLPPriceFeed(address(0), WNLP_S5B, SPCXB, "x");
+  }
+
+  function test_revertsOnZeroWNLP() public {
+    vm.expectRevert("wNLPPriceFeed/zero-address");
+    new wNLPPriceFeed(RESILIENT_ORACLE, address(0), SPCXB, "x");
+  }
+
+  function test_revertsOnZeroUnderlying() public {
+    vm.expectRevert("wNLPPriceFeed/zero-address");
+    new wNLPPriceFeed(RESILIENT_ORACLE, WNLP_S5B, address(0), "x");
+  }
+
+  /// @dev An underlying with no ResilientOracle config makes peek revert, so the
+  /// feed fails closed rather than reporting a bogus price.
+  function test_revertsWhenUnderlyingHasNoOracleConfig() public {
+    // NLP-S5B itself is not configured on the ResilientOracle
+    address unconfigured = 0x4EE1C93Eb1Ca08f566211fb18A8Dc5c1C6d04939;
+    wNLPPriceFeed feed = _deploy(WNLP_S5B, unconfigured, "bad");
+    vm.expectRevert();
+    feed.latestAnswer();
+  }
+}


### PR DESCRIPTION
## 📄 Description

Adds `wNLPPriceFeed`, a generic Chainlink-shaped price feed for any Native `wNLP-*` wrapper. It reads the `wNLP/underlying` exchange rate from the wrapper (`getNlpByWnlp`) and the `underlying/USD` price from the Lista `ResilientOracle` (`peek`), and returns `wNLP/USD` in 8 decimals via `AggregatorV3Interface`.

The first consumer is **wNLP-S5B** (product name **nSPCXB**), the collateral of the upcoming nSPCXB / SPCXB whitelist market. A deploy script wires the wNLP-S5B / SPCXB pair, and BSC fork tests cover both the new asset and behaviour-equivalence with the already-live hardcoded wNLP-USDT feed.

## 🧠 Rationale

The existing wNLP-USDT feed hardcodes its wrapper and underlying addresses, so every new `wNLP-*` token would need its own copy of the file. wNLP-S5B is the second such token and more are expected, so this PR replaces the copy-per-token pattern with a single parameterised contract: the wrapper, underlying and description are constructor immutables, and the contract has no admin.

Registering this feed as the MAIN oracle of wNLP-S5B on the `ResilientOracle` is a hard prerequisite for creating the nSPCXB / SPCXB market — `Moolah.createMarket` peeks both market tokens and reverts while the collateral has no price.

Design follows the existing `AtlasOracleAdaptor` (constructor-injected source, 8-decimal `AggregatorV3Interface`, `FullMath.mulDiv` rescaling, no in-contract staleness check) and `LisAsterPriceFeed` conventions in this repo.

## 🧪 Example / Testing

`forge test --match-path test/oracle/wNLPPriceFeed.t.sol -vv` — 8 BSC-fork tests, all passing:

```
[PASS] test_S5B_metadata()
[PASS] test_S5B_priceAboveUnderlying()
[PASS] test_S5B_priceMatchesRateTimesUnderlying()
        wNLP-S5B rate (1e18): 1015127197851109475
        SPCXB price (1e8)   : 11587850128
        wNLP-S5B price (1e8): 11763141829
[PASS] test_USDT_matchesDeployedHardcodedFeed()
        generic  wNLP-USDT (1e8): 101712749
        deployed wNLP-USDT (1e8): 101712749
[PASS] test_revertsOnZeroResilientOracle()
[PASS] test_revertsOnZeroUnderlying()
[PASS] test_revertsOnZeroWNLP()
[PASS] test_revertsWhenUnderlyingHasNoOracleConfig()
```

- `test_S5B_priceMatchesRateTimesUnderlying` asserts the feed equals `peek(SPCXB) * getNlpByWnlp(1e18) / 1e18`.
- `test_USDT_matchesDeployedHardcodedFeed` feeds the generic contract the wNLP-USDT pair and asserts byte-for-byte equality with the deployed feed `0xf86155a2…` at the same block — proving no behavioural drift from the precedent.
- Negative tests confirm zero-address reverts at construction and a fail-closed revert when the underlying has no ResilientOracle config.

Deploy (wNLP-S5B):

```bash
forge script script/oracle/deployWNLPSPCXBPriceFeed.sol:DeployWNLPSPCXBPriceFeed \
  --rpc-url bsc --private-key $DEPLOYER_PRIVATE_KEY --broadcast --verify -vvvv
```

Post-deploy the feed must still be registered as the MAIN oracle of wNLP-S5B on the `ResilientOracle` (`setTokenConfigs`) with a matching `BoundValidator` entry, via the Ops multi-sig, before `peek(wNLP-S5B)` resolves.

## 🧬 Changes Summary

Notable changes:
* `src/oracle/wNLPPriceFeed.sol` — new generic `wNLP-*/USD` feed (8-decimal `AggregatorV3Interface`; wrapper / underlying / description as constructor immutables; `FullMath.mulDiv`; no admin, no in-contract staleness guard on the rate leg — monitored off-chain).
* `src/oracle/interfaces/OracleInterface.sol` — add `IWNLP { getNlpByWnlp(uint256) }`.
* `script/oracle/deployWNLPSPCXBPriceFeed.sol` — deploys the wNLP-S5B (nSPCXB) instance with the SPCXB underlying and the Lista ResilientOracle.
* `test/oracle/wNLPPriceFeed.t.sol` — 8 BSC fork tests: price formula, accrual direction, metadata, equivalence with the deployed wNLP-USDT feed, and negative cases.
